### PR TITLE
daysAfterDate and daysBeforeDate don't take into account daylight savings changes

### DIFF
--- a/SwiftDate/SwiftDate.swift
+++ b/SwiftDate/SwiftDate.swift
@@ -487,53 +487,53 @@ public extension NSDate {
 //MARK: COMPARE DATES
 
 public extension NSDate {
-	
+    
     func secondsAfterDate(date: NSDate) -> Int {
-        let interval = self.timeIntervalSinceDate(date)
-        return Int(interval)
+        let components = NSCalendar.currentCalendar().components(NSCalendarUnit.Second, fromDate: date, toDate: self, options: [])
+        return components.second
     }
     
     func secondsBeforeDate(date: NSDate) -> Int {
-        let interval = date.timeIntervalSinceDate(self)
-        return Int(interval)
+        let components = NSCalendar.currentCalendar().components(NSCalendarUnit.Second, fromDate: self, toDate: date, options: [])
+        return components.second
     }
     
     /**
-	Return the number of minutes between two dates.
-	
-	:param: date comparing date
-	
-	:returns: number of minutes
-	*/
-	func minutesAfterDate(date: NSDate) -> Int {
-		let interval = self.timeIntervalSinceDate(date)
-		return Int(interval / NSTimeInterval(D_MINUTE))
-	}
-	
-	func minutesBeforeDate(date: NSDate) -> Int {
-		let interval = date.timeIntervalSinceDate(self)
-		return Int(interval / NSTimeInterval(D_MINUTE))
-	}
-	
-	func hoursAfterDate(date: NSDate) -> Int {
-		let interval = self.timeIntervalSinceDate(date)
-		return Int(interval / NSTimeInterval(D_HOUR))
-	}
-	
-	func hoursBeforeDate(date: NSDate) -> Int {
-		let interval = date.timeIntervalSinceDate(self)
-		return Int(interval / NSTimeInterval(D_HOUR))
-	}
-	
-	func daysAfterDate(date: NSDate) -> Int {
-		let interval = self.timeIntervalSinceDate(date)
-		return Int(interval / NSTimeInterval(D_DAY))
-	}
-	
-	func daysBeforeDate(date: NSDate) -> Int {
-		let interval = date.timeIntervalSinceDate(self)
-		return Int(interval / NSTimeInterval(D_DAY))
-	}
+    Return the number of minutes between two dates.
+    
+    :param: date comparing date
+    
+    :returns: number of minutes
+    */
+    func minutesAfterDate(date: NSDate) -> Int {
+        let components = NSCalendar.currentCalendar().components(NSCalendarUnit.Minute, fromDate: date, toDate: self, options: [])
+        return components.minute
+    }
+    
+    func minutesBeforeDate(date: NSDate) -> Int {
+        let components = NSCalendar.currentCalendar().components(NSCalendarUnit.Minute, fromDate: self, toDate: date, options: [])
+        return components.minute
+    }
+    
+    func hoursAfterDate(date: NSDate) -> Int {
+        let components = NSCalendar.currentCalendar().components(NSCalendarUnit.Hour, fromDate: date, toDate: self, options: [])
+        return components.hour
+    }
+    
+    func hoursBeforeDate(date: NSDate) -> Int {
+        let components = NSCalendar.currentCalendar().components(NSCalendarUnit.Hour, fromDate: self, toDate: date, options: [])
+        return components.hour
+    }
+    
+    func daysAfterDate(date: NSDate) -> Int {
+        let components = NSCalendar.currentCalendar().components(NSCalendarUnit.Day, fromDate: date, toDate: self, options: [])
+        return components.day
+    }
+    
+    func daysBeforeDate(date: NSDate) -> Int {
+        let components = NSCalendar.currentCalendar().components(NSCalendarUnit.Day, fromDate: self, toDate: date, options: [])
+        return components.day
+    }
 	
 	/**
 	Compare two dates and return true if they are equals

--- a/SwiftDateTests/SwiftDateTests.swift
+++ b/SwiftDateTests/SwiftDateTests.swift
@@ -63,4 +63,10 @@ class SwiftDateTests: XCTestCase {
         XCTAssertEqual(now - now, NSTimeInterval(0))
         XCTAssertEqual(now - after, NSTimeInterval(-60))
     }
+    
+    func test_secondsAfterDate() {
+        let summerTimeDay = NSDate.date(refDate: nil, year: 2015, month: 3, day: 29, tz: nil)
+        let nextDay = NSDate.date(refDate: nil, year: 2015, month: 3, day: 30, tz: nil)
+        XCTAssertEqual(summerTimeDay.daysAfterDate(nextDay), -1)
+    }
 }


### PR DESCRIPTION
A day doesn't aways have 24 hours, so the following methods are prone to errors for date ranges spanning a clock change. The interval calculations should be done using NSCalendar.

This is particularly problematic since `add` does take into account the user's timezone, so with this library you can add 1 day with `add` and get 0 days back when using `daysBeforeDate` or `daysAfterDate`.