### PR TITLE
Fix ISO8601Formatter parsing dates that end in Z

### DIFF
--- a/SwiftDate/SwiftDate.swift
+++ b/SwiftDate/SwiftDate.swift
@@ -216,11 +216,20 @@ public extension NSDate {
 			// YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
 			case CompleteDatePlusHoursAndMinutes = 22
 			
-			//YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
+			// YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20Z)
+			case CompleteDatePlusHoursAndMinutesAndZ = 17
+			
+			// YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
 			case CompleteDatePlusHoursMinutesAndSeconds = 25
+			
+			// YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30Z)
+			case CompleteDatePlusHoursAndMinutesAndSecondsAndZ = 20
 			
 			// YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
 			case CompleteDatePlusHoursMinutesSecondsAndDecimalFractionOfSecond = 28
+			
+			// YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45Z)
+			case CompleteDatePlusHoursMinutesSecondsAndDecimalFractionOfSecondAndZ = 23
 		}
 		
 		var dateFormatter = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
@@ -233,12 +242,11 @@ public extension NSDate {
 				dateFormatter = "yyyy-MM"
 			case .CompleteDate:
 				dateFormatter = "yyyy-MM-dd"
-			case .CompleteDatePlusHoursAndMinutes:
+			case .CompleteDatePlusHoursAndMinutes, .CompleteDatePlusHoursAndMinutesAndZ:
 				dateFormatter = "yyyy-MM-dd'T'HH:mmZ"
-			case .CompleteDatePlusHoursMinutesAndSeconds:
+			case .CompleteDatePlusHoursMinutesAndSeconds, .CompleteDatePlusHoursAndMinutesAndSecondsAndZ:
 				dateFormatter = "yyyy-MM-dd'T'HH:mm:ssZ"
-			default:
-				// YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
+			case .CompleteDatePlusHoursMinutesSecondsAndDecimalFractionOfSecond, .CompleteDatePlusHoursMinutesSecondsAndDecimalFractionOfSecondAndZ:
 				dateFormatter = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
 			}
 		}

--- a/SwiftDateTests/SwiftDateTests.swift
+++ b/SwiftDateTests/SwiftDateTests.swift
@@ -69,4 +69,28 @@ class SwiftDateTests: XCTestCase {
         let nextDay = NSDate.date(refDate: nil, year: 2015, month: 3, day: 30, tz: nil)
         XCTAssertEqual(summerTimeDay.daysAfterDate(nextDay), -1)
     }
+
+    func test_toDateISO8601ParsesDateWithHoursMinutesAndZ() {
+        let expectedDate = NSDate.date(refDate: nil, year: 2015, month: 9, day: 29, hour: 0, minute: 0, second: 0, tz: "UTC")
+
+        let parsedDate = NSDate.date(fromString: "2015-09-29T00:00Z", format: .ISO8601)
+
+        XCTAssertEqual(parsedDate, expectedDate)
+    }
+
+    func test_toDateISO8601ParsesDateWithHoursMinutesSecondsAndZ() {
+        let expectedDate = NSDate.date(refDate: nil, year: 2015, month: 9, day: 29, hour: 0, minute: 0, second: 0, tz: "UTC")
+
+        let parsedDate = NSDate.date(fromString: "2015-09-29T00:00:00Z", format: .ISO8601)
+
+        XCTAssertEqual(parsedDate, expectedDate)
+    }
+
+    func test_toDateISO8601ParsesDateWithHoursMinutesSecondsAndFractionAndZ() {
+        let expectedDate = NSDate.date(refDate: nil, year: 2015, month: 9, day: 29, hour: 0, minute: 0, second: 0, tz: "UTC")
+
+        let parsedDate = NSDate.date(fromString: "2015-09-29T00:00:00.000Z", format: .ISO8601)
+
+        XCTAssertEqual(parsedDate, expectedDate)
+    }
 }


### PR DESCRIPTION
Why:

> Times are expressed in UTC (Coordinated Universal Time), with a special UTC designator ("Z").
> http://www.w3.org/TR/NOTE-datetime

* `ISO8601Formatter` would fail to parse dates(unless it hit the default case) ending in Z

This change addresses the need by:

* Adding Enum cases to support character counts for dates with Z
* Remove default case of the switch by making it exhaustive
* Add tests for these cases