### PR TITLE
Time of the interval exists for `isSameYearOf`

### DIFF
--- a/SwiftDate/SwiftDate.swift
+++ b/SwiftDate/SwiftDate.swift
@@ -755,7 +755,8 @@ public extension NSDate {
 	
 	/// Returns true if the date is in the same month of passed date
 	func isSameMonthOf(date: NSDate) -> Bool {
-		return self >= date.beginningOfMonth && self <= date.endOfMonth
+        let beginningOfMonth = date.beginningOfMonth
+        return self >= beginningOfMonth && self < beginningOfMonth.add(months: 1)
 	}
 	
 	/// Return the first day of the year of the current date
@@ -770,7 +771,8 @@ public extension NSDate {
 	
 	/// Returns true if the date is in the same year of passed date
 	func isSameYearOf(date: NSDate) -> Bool {
-		return self >= date.beginningOfYear && self <= date.endOfYear
+        let beginningOfYear = date.beginningOfYear
+        return self >= beginningOfYear && self < beginningOfYear.add(years: 1)
 	}
 	
 	/**

--- a/SwiftDateTests/SwiftDateTests.swift
+++ b/SwiftDateTests/SwiftDateTests.swift
@@ -103,4 +103,14 @@ class SwiftDateTests: XCTestCase {
         let ac2015 = NSDate.date(refDate: nil, year: 2015, month: 9, day: 29, hour: 0, minute: 0, second: 0, tz: "UTC")
         XCTAssertFalse(bc2015.isEqualToDate(ac2015, ignoreTime: true) , "not eq B.C. and A.C.")
     }
+    
+    func test_isSmaeYearOf() {
+        let endOfYear = NSDate.date(refDate: nil, year: 2015, month: 12, day: 31, hour: 23, minute: 59, second: 59, tz: nil)
+        let betweenTime = endOfYear.dateByAddingTimeInterval(0.5)
+        let beginOfYear = NSDate.date(refDate: nil, year: 2016, month: 1, day: 1, tz: nil)
+        XCTAssert(endOfYear.isSameYearOf(betweenTime))
+        XCTAssert(betweenTime.isSameYearOf(endOfYear))
+        XCTAssertFalse(endOfYear.isSameYearOf(beginOfYear))
+        XCTAssertFalse(betweenTime.isSameYearOf(beginOfYear))
+    }
 }


### PR DESCRIPTION
Interval exists between the beginningOfDay and endOfDay of this library. You can define the beginning time, but can not define the end time. If possible, the better to obsolete the endOfDay.

https://en.wikipedia.org/wiki/Dedekind_cut