### PR TITLE
Enable to use optional values to initialize date 

### DIFF
--- a/SwiftDate/SwiftDate.swift
+++ b/SwiftDate/SwiftDate.swift
@@ -283,7 +283,7 @@ public extension NSDate {
 	
 	:returns: a new NSDate with components changed according to passed params
 	*/
-	class func date(refDate refDate: NSDate?, year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int, tz: String?) -> NSDate {
+	class func date(refDate refDate: NSDate?, year: Int?, month: Int?, day: Int?, hour: Int?, minute: Int?, second: Int?, tz: String?) -> NSDate {
 		let referenceDate = refDate ?? NSDate()
 		return referenceDate.set(year: year, month: month, day: day, hour: hour, minute: minute, second: second, tz: tz)
 	}


### PR DESCRIPTION
I think the date initializer's arguments' types are not correct.
The README document says the following date initializer can be used like 

```
let date_from_components = NSDate.date(refDate: nil, year: 2014, month: 01, day: nil, hour: nil, minute: nil, second: nil, tz: "UTC")
```
But in fact, it defined as nil can't be used, so if I use this method like the above example I face a compile error.

I fixed this by allowing optinal values.