### PR TITLE
Bug on toLocalTime() function

### DIFF
--- a/SwiftDate/SwiftDate.swift
+++ b/SwiftDate/SwiftDate.swift
@@ -471,7 +471,7 @@ public extension NSDate {
 	*/
 	func toLocalTime() -> NSDate {
 		let tz : NSTimeZone = NSTimeZone.localTimeZone()
-		let secs : Int = -tz.secondsFromGMTForDate(self)
+		let secs : Int = tz.secondsFromGMTForDate(self)
 		return NSDate(timeInterval: NSTimeInterval(secs), sinceDate: self)
 	}
 	


### PR DESCRIPTION
The function toLocalTime() always removed secondsFromGMT. This is wrong for GMT+X timezone. I removed the minus because secondsFromGMTForDate() will return +/-X secondes according to the GMT ... In France it's +7200 and in PST it's -25 200 so it's not needed to force minus this amount of seconds ...