### PR TITLE
Add extensions to NSTimeInterval to convert to different time units

### DIFF
--- a/Sources/SwiftDate/NSTimeInterval+SwiftDate.swift
+++ b/Sources/SwiftDate/NSTimeInterval+SwiftDate.swift
@@ -24,6 +24,12 @@
 
 import Foundation
 
+private let NANOSECONDS_IN_SECOND = 1000.0
+private let SECONDS_IN_MINUTE = 60.0
+private let MINUTES_IN_HOUR = 60.0
+private let HOURS_IN_DAY = 24.0
+private let DAYS_IN_WEEK = 7.0
+
 public extension NSTimeInterval {
 
 	/// Returns an NSDate object initialized relative to the current date and time
@@ -52,4 +58,40 @@ public extension NSTimeInterval {
 			return formatter.stringFromTimeInterval(self)
 		})
 	}
+
+    /// Returns a this NSTimeInterval in nanoseconds
+    ///
+    public var nanoseconds: Double {
+        return seconds * NANOSECONDS_IN_SECOND
+    }
+
+    /// Returns a this NSTimeInterval in seconds
+    ///
+    public var seconds: Double {
+        return self
+    }
+
+    /// Returns a this NSTimeInterval in minutes
+    ///
+    public var minutes: Double {
+        return seconds / SECONDS_IN_MINUTE
+    }
+
+    /// Returns a this NSTimeInterval in hours
+    ///
+    public var hours: Double {
+        return minutes / MINUTES_IN_HOUR
+    }
+
+    /// Returns a this NSTimeInterval in days
+    ///
+    public var days: Double {
+        return hours / HOURS_IN_DAY
+    }
+
+    /// Returns a this NSTimeInterval in weeks
+    ///
+    public var weeks: Double {
+        return days / DAYS_IN_WEEK
+    }
 }

--- a/Sources/SwiftDateTests/NSTimeIntervalTests.swift
+++ b/Sources/SwiftDateTests/NSTimeIntervalTests.swift
@@ -43,6 +43,44 @@ class NSTimeIntervalSpec: QuickSpec {
                     expect(interval.toString()) == "10y 9m 5d 22h"
                 }
             }
+
+            context("conversions") {
+                it ("should return nanoseconds") {
+                    let timeInterval = NSTimeInterval(4)
+                    let nanoseconds = timeInterval.nanoseconds
+                    expect(nanoseconds) == 4000.0
+                }
+
+                it ("should return seconds") {
+                    let timeInterval = NSTimeInterval(4)
+                    let seconds = timeInterval.seconds
+                    expect(seconds) == 4.0
+                }
+
+                it ("should return minutes") {
+                    let timeInterval = NSTimeInterval(150)
+                    let minutes = timeInterval.minutes
+                    expect(minutes) == 2.5
+                }
+
+                it ("should return hours") {
+                    let timeInterval = NSTimeInterval(5400)
+                    let hours = timeInterval.hours
+                    expect(hours) == 1.5
+                }
+
+                it ("should return days") {
+                    let timeInterval = NSTimeInterval(172800)
+                    let days = timeInterval.days
+                    expect(days) == 2.0
+                }
+
+                it ("should return weeks") {
+                    let timeInterval = NSTimeInterval(2419200)
+                    let weeks = timeInterval.weeks
+                    expect(weeks) == 4.0
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
To be able to find out the time between two NSDate instances I thought it would be nice to extend NSTimeInterval with some calculated properties that convert it into different units.

E.g.
```
let interval: NSTimeInterval = 60.0
let minutes = interval.minutes
print(minutes) // prints 1.0
```

This also allows to check how much time there was between to NSDates.
```
let now = NSDate()
let someTimeAgo = 4.hours.ago
let hourDifference = now.timeIntervalSinceDate(someTimeAgo).hours
print(hourDifference) // prints 4.0
```