### PR TITLE
Support the shortMonthName property

### DIFF
--- a/Documentation/UserGuide.md
+++ b/Documentation/UserGuide.md
@@ -176,6 +176,7 @@ Property/function|Description|NSDate|DateInRegion
 `yearForWeekOfYear`|Returns the year number for the weekOfYear of the receiver|x|x
 `month`|Returns the month number (1...12) of the receiver|x|x
 `monthName`|Returns the month name of the receiver|x|x
+`shortMonthName`|Returns the short month name of the receiver|x|x
 `monthDays`|Returns the number of days in the month (28...31) of the receiver|x|x
 `weekOfYear`|Returns the week number in the year (1...53) of the receiver|x|x
 `weekOfMonth`|Returns the week number in the month (0...5) of the receiver|x|x
@@ -214,7 +215,7 @@ Function|Description|NSDate|DateInRegion|DateRegion
 
 All `NSDate` functions are evaluated against the current region by default. If you want a value for another region you can add the `inRegion:` parameter. E.g. `nsdate.nextWeekend(inRegion: china)` will return the start and end of the next weekend in China. Mind that the return values are `NSDate` objects. If you want `DateInRegion` return values then you can use `nsdate.inRegion(china).nextWeekend()`. This will create a `DateInRegion` object from the `nsdate` object and then evaluate the `nextWeekend` function.
 
-The properties `monthName` and `weekdayName` return `String` objects against the current locale for `NSDate` and for the locale registered with the `DateRegion` for `DateInRegion`.  
+The properties `monthName`, `shortMonthName` and `weekdayName` return `String` objects against the current locale for `NSDate` and for the locale registered with the `DateRegion` for `DateInRegion`.  
 
 ## Calculations with `DateInRegion`/`NSDate`
 Add (`+`) and subtract (`-`) operators are supported both for `NSDate` and `DateInRegion`.

--- a/Sources/SwiftDate/DateInRegion+Components.swift
+++ b/Sources/SwiftDate/DateInRegion+Components.swift
@@ -214,6 +214,15 @@ public extension DateInRegion {
 		}!
     }
 
+    /// Short month name of the date expressed in this region's timezone using region's locale
+    public var shortMonthName: String {
+        let cachedFormatter = sharedDateFormatter()
+        return cachedFormatter.beginSessionContext { () -> (String) in
+            cachedFormatter.locale = self.region.locale
+            let value = cachedFormatter.shortMonthSymbols[self.month - 1] as String
+            return value
+        }!
+    }
 
     /// Boolean value that indicates whether the month is a leap month.
     /// ``YES`` if the month is a leap month, ``NO`` otherwise

--- a/Sources/SwiftDate/NSDate+SwiftDate.swift
+++ b/Sources/SwiftDate/NSDate+SwiftDate.swift
@@ -421,6 +421,12 @@ extension NSDate {
     public var monthName: String {
         return self.inRegion().monthName
     }
+    
+    /// Get the short month name component of the date in current region (use inRegion(...).shortMonthName to
+    /// get the month's short name component in specified time zone)
+    public var shortMonthName: String {
+        return self.inRegion().shortMonthName
+    }
 
     /// Get the week of month component of the date in current region (use inRegion(...).weekOfMonth
     /// to get the week of month component in specified time zone)

--- a/Sources/SwiftDateTests/NSDateTests.swift
+++ b/Sources/SwiftDateTests/NSDateTests.swift
@@ -490,7 +490,11 @@ class NSDateSpec: QuickSpec {
             }
 
             context("components") {
-
+                
+                it("should report proper short month names") {
+                    expect(date.shortMonthName) == "Feb"
+                }
+                
                 it("should report proper month names") {
                     expect(date.monthName) == "February"
                 }


### PR DESCRIPTION
I sometimes want to use the short month name (e.g. "Jan. 1st"). Please review my change.