### PR TITLE
Add Region.defaultRegionProvider and defaultRegion()

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+# Use this plugin in Xcode: https://github.com/MarcoSero/EditorConfig-Xcode
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[**.swift]
+indent_style = space
+indent_size = 4

--- a/Sources/SwiftDate/DateInRegion.swift
+++ b/Sources/SwiftDate/DateInRegion.swift
@@ -101,7 +101,7 @@ public struct DateInRegion {
     ///
     public init(absoluteTime newDate: NSDate? = nil, region newRegion: Region? = nil) {
         absoluteTime = newDate ?? NSDate()
-        region = newRegion ?? Region()
+        region = newRegion ?? Region.defaultRegion()
     }
 
     /// Initialise a `DateInRegion` object from a set of date components. Default values will be
@@ -264,7 +264,7 @@ public struct DateInRegion {
     public init?(fromString dateString: String, format: DateFormat,
         region nilRegion: Region? = nil) {
 
-            let region = nilRegion ?? Region()
+            let region = nilRegion ?? Region.defaultRegion()
 
 			let cFormatter = sharedDateFormatter()
 			let parsedDate = cFormatter.beginSessionContext { () -> (NSDate?) in

--- a/Sources/SwiftDate/NSDate+SwiftDate.swift
+++ b/Sources/SwiftDate/NSDate+SwiftDate.swift
@@ -120,7 +120,7 @@ extension NSDate {
     /// - parameter minute: minute to set  (nil to ignore)
     /// - parameter second: second to set  (nil to ignore)
     /// - parameter nanosecond: nanosecond to set  (nil to ignore)
-    /// - parameter region: region to set (if not specified Region() will be used instead
+    /// - parameter region: region to set (if not specified Region.defaultRegion() will be used instead
     ///
     @available(*, renamed="init(fromDate, ...)")
     public convenience init(refDate date: NSDate, era: Int? = nil, year: Int? = nil,
@@ -542,7 +542,7 @@ extension NSDate {
 
 
     public func isInSameDayAsDate(date: NSDate, inRegion optRegion: Region? = nil) -> Bool {
-        let region = optRegion ?? Region()
+        let region = optRegion ?? Region.defaultRegion()
         return self.inRegion(region).isInSameDayAsDate(date.inRegion(region))
     }
 
@@ -593,17 +593,17 @@ extension NSDate {
 extension NSDate {
 
     public class func today(inRegion optRegion: Region? = nil) -> NSDate {
-        let region = optRegion ?? Region()
+        let region = optRegion ?? Region.defaultRegion()
         return region.today().absoluteTime
     }
 
     public class func yesterday(inRegion optRegion: Region? = nil) -> NSDate {
-        let region = optRegion ?? Region()
+        let region = optRegion ?? Region.defaultRegion()
         return region.yesterday().absoluteTime
     }
 
     public class func tomorrow(inRegion optRegion: Region? = nil) -> NSDate {
-        let region = optRegion ?? Region()
+        let region = optRegion ?? Region.defaultRegion()
         return region.tomorrow().absoluteTime
     }
 

--- a/Sources/SwiftDate/NSDateComponents+SwiftDate.swift
+++ b/Sources/SwiftDate/NSDateComponents+SwiftDate.swift
@@ -37,7 +37,7 @@ public extension NSDateComponents {
 
      - returns: a new NSDate instance
      */
-    public func fromDate(refDate: NSDate!, inRegion region: Region = Region()) -> NSDate {
+    public func fromDate(refDate: NSDate!, inRegion region: Region = Region.defaultRegion()) -> NSDate {
         let date = region.calendar.dateByAddingComponents(self, toDate: refDate,
             options: NSCalendarOptions(rawValue: 0))
         return date!
@@ -52,7 +52,7 @@ public extension NSDateComponents {
 
      - returns: a new NSDate instance
      */
-    public func agoFromDate(refDate: NSDate!, inRegion region: Region = Region()) -> NSDate {
+    public func agoFromDate(refDate: NSDate!, inRegion region: Region = Region.defaultRegion()) -> NSDate {
         for unit in DateInRegion.componentFlagSet {
             let value = self.valueForComponent(unit)
             if value != NSDateComponentUndefined {
@@ -73,7 +73,7 @@ public extension NSDateComponents {
 
      - returns: a new NSDate instance
      */
-    public func fromNow(inRegion region: Region = Region()) -> NSDate {
+    public func fromNow(inRegion region: Region = Region.defaultRegion()) -> NSDate {
         return fromDate(NSDate(), inRegion: region)
     }
 
@@ -87,7 +87,7 @@ public extension NSDateComponents {
 
      - returns: a new NSDate instance
      */
-    public func ago(inRegion region: Region = Region()) -> NSDate {
+    public func ago(inRegion region: Region = Region.defaultRegion()) -> NSDate {
         return agoFromDate(NSDate())
     }
 

--- a/Sources/SwiftDate/Region.swift
+++ b/Sources/SwiftDate/Region.swift
@@ -56,6 +56,12 @@ public struct Region: Equatable {
         return self.calendar.locale!
     }
 
+    /// Closure used by defaultRegion().
+    /// You can override library-wide default to any Region object,
+    /// or memoize Region to reduce overhead of NSCalendar initialization.
+    ///
+    public static var defaultRegionProvider: (() -> Region)?
+
     /// Initialise with a calendar and/or a time zone
     ///
     /// - Parameters:
@@ -133,6 +139,17 @@ public struct Region: Equatable {
         return today() + 1.days
     }
 
+    /// Default Region provided by defaultRegionProvider,
+    /// or Region() if not set.
+    ///
+    /// - Returns: the Region object
+    ///
+    public static func defaultRegion() -> Region {
+        if let provider = Region.defaultRegionProvider {
+            return provider()
+        }
+        return Region()
+    }
 }
 
 public func == (left: Region, right: Region) -> Bool {

--- a/Sources/SwiftDateTests/NSDateTests.swift
+++ b/Sources/SwiftDateTests/NSDateTests.swift
@@ -507,6 +507,16 @@ class NSDateSpec: QuickSpec {
 
             context("components") {
 
+                beforeEach {
+                    Region.defaultRegionProvider = {
+                        Region(calendarName: .Gregorian, timeZoneName: .Gmt, localeName: .EnglishUnitedStates)
+                    }
+                }
+
+                afterEach {
+                    Region.defaultRegionProvider = nil
+                }
+
                 it("should report proper month names") {
                     expect(date.monthName) == "February"
                 }
@@ -529,9 +539,13 @@ class NSDateSpec: QuickSpec {
                 let date = NSDate(year: 2001, month: 2, day: 3)
 
                 it("should get default region") {
+                    defer { Region.defaultRegionProvider = nil }
 
                     expect(date.inDefaultRegion()) == date.inRegion()
 
+                    Region.defaultRegionProvider = { Region(calendarName: .AutoUpdatingCurrent) }
+
+                    expect(date.inDefaultRegion()) == date.inRegion()
                 }
 
             }

--- a/Sources/SwiftDateTests/NSTimeIntervalTests.swift
+++ b/Sources/SwiftDateTests/NSTimeIntervalTests.swift
@@ -36,8 +36,10 @@ class NSTimeIntervalSpec: QuickSpec {
             }
 
             context("toString") {
+
                 it("should return the proper string") {
-                    let rome = Region(timeZoneName: .EuropeRome)
+                    // NOTE: This test may fail if locale is not en_US.
+                    let rome = Region(calendarName: .Gregorian, timeZoneName: .EuropeRome, localeName: .System)
                     let date = NSDate(year: 2011, month: 10, day: 9, region: rome)
                     let interval = date.timeIntervalSinceReferenceDate
                     expect(interval.toString()) == "10y 9m 5d 22h"

--- a/Sources/SwiftDateTests/RegionStringTests.swift
+++ b/Sources/SwiftDateTests/RegionStringTests.swift
@@ -73,8 +73,20 @@ class DateRegionStringSpec: QuickSpec {
 
             context("toString local") {
 
+                let region = Region(calendarName: .Gregorian, timeZoneName: .Gmt, localeName: .EnglishUnitedStates)
+
+                beforeEach {
+                    Region.defaultRegionProvider = { region }
+                }
+
+                afterEach {
+                    Region.defaultRegionProvider = nil
+                }
+
+                NSTimeZone.setDefaultTimeZone(TimeZoneName.Gmt.timeZone)
                 let date = NSDate(year: 2015, month: 4, day: 13, hour: 22, minute: 10)
-                let localDate = date.inRegion()
+                let localDate = date.inRegion(region)
+                NSTimeZone.setDefaultTimeZone(NSTimeZone.systemTimeZone())
 
                 it("should return proper ISO 8601 string") {
                     expect(localDate.toString(DateFormat.ISO8601Format(.Full))!.hasPrefix("2015-04-13T22:10:00")) == true

--- a/Sources/SwiftDateTests/RegionTests.swift
+++ b/Sources/SwiftDateTests/RegionTests.swift
@@ -110,6 +110,25 @@ class DateregionSpec: QuickSpec {
 
             }
 
+            context("default region") {
+
+                it("should return Region with default args if no provider is set") {
+                    let region = Region.defaultRegion()
+
+                    expect(region) == Region()
+                }
+
+                it("should return Region from provider if set") {
+                    Region.defaultRegionProvider = { Region(calendarName: .AutoUpdatingCurrent) }
+                    defer { Region.defaultRegionProvider = nil }
+
+                    let region = Region.defaultRegion()
+
+                    expect(region) == Region(calendarName: .AutoUpdatingCurrent)
+                }
+
+            }
+
 
         }
     }

--- a/XCode/Cartfile.private
+++ b/XCode/Cartfile.private
@@ -1,2 +1,2 @@
 github "Quick/Quick"
-github "Quick/Nimble"
+github "Quick/Nimble" ~> 3.2.0


### PR DESCRIPTION
I found that recently defaultRegion is removed, after writing this patch.....
But I think it is necessary for following reasons:

- To cache Region object to get rid of overhead of NSCalendar initialization.
- Currently tests depending on default locale fail in non-English locale machine.

It could be implemented as built-in caching mechanism, but provider enables to controll cache storage and lifecycle by library user.

### Caching example

```swift
Region.defaultRegionProvider = {
    if let cachedRegion = NSThread.currentThread().threadDictionary[kCacheKey] {
        return cachedRegion
    }
    let region = Region(...)
    NSThread.currentThread().threadDictionary[kCacheKey] = region
    return region
}