### PR TITLE
turn platform ios build setting Require only App-extension safe to YES

### DIFF
--- a/XCode/SwiftDate.xcodeproj/project.pbxproj
+++ b/XCode/SwiftDate.xcodeproj/project.pbxproj
@@ -917,8 +917,13 @@
 		90F1F38F1C7F6AF500B22B90 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
+<<<<<<< Updated upstream
 				CLANG_ENABLE_MODULES = YES;
+=======
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+>>>>>>> Stashed changes
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -941,8 +946,13 @@
 		90F1F3901C7F6AF500B22B90 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
+<<<<<<< Updated upstream
 				CLANG_ENABLE_MODULES = YES;
+=======
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+>>>>>>> Stashed changes
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
turn platform ios build setting Require only App-extension safe to YES