### PR TITLE
Missing inRegion parameter in ago()

### DIFF
--- a/Sources/SwiftDate/NSDateComponents+SwiftDate.swift
+++ b/Sources/SwiftDate/NSDateComponents+SwiftDate.swift
@@ -88,7 +88,7 @@ public extension NSDateComponents {
      - returns: a new NSDate instance
      */
     public func ago(inRegion region: Region = Region()) -> NSDate {
-        return agoFromDate(NSDate())
+        return agoFromDate(NSDate(), inRegion: region)
     }
 
     /// The same of calling fromNow() with default local region


### PR DESCRIPTION
The optional region parameter is not correctly passed to the agoFromDate() method.