### PR TITLE
Adding support for julian days

### DIFF
--- a/Sources/SwiftDate/DateInRegion+Components.swift
+++ b/Sources/SwiftDate/DateInRegion+Components.swift
@@ -249,6 +249,36 @@ public extension DateInRegion {
         // For other calendars:
         return calendar.components([.Day, .Month, .Year], fromDate: absoluteTime).leapMonth
     }
+    
+    /// The julian day corresponding to the current civil date. Note that it is often called Julian Date.
+    /// But we prefer Jean Meeus reference textboox where he explains the julian day isn't a Date, but rather a Day.
+    /// The formula can be found in http://scienceworld.wolfram.com/astronomy/JulianDate.html 
+    /// It is valid between 1901 and 2099.
+    ///
+    /// - Returns the Julian Day of the date.
+    ///
+    public func julianDay() -> Double {
+        let utc = self.inRegion(DateRegion(calendarName: .Gregorian, timeZoneName: .Gmt, localeName: .English))
+        
+        let year = Double(utc.year)
+        let month = Double(utc.month)
+        let day = Double(utc.day)
+        let hour = Double(utc.hour) + Double(utc.minute)/60.0 + (Double(utc.second)+Double(utc.nanosecond)/1e9)/3600.0
+        
+        var jd = 367.0*year - floor( 7.0*( year+floor((month+9.0)/12.0))/4.0 )
+        jd -= floor( 3.0*(floor( (year+(month-9.0)/7.0)/100.0 ) + 1.0)/4.0 )
+        jd += floor(275.0*month/9.0) + day + 1721028.5 + hour/24.0
+        
+        return jd
+    }
+    
+    /// Most popular variant of JD.
+    ///
+    /// - Returns the Modified Julain Day of the date.
+    ///
+    public func modifiedJulianDay() -> Double {
+        return self.julianDay() - 2400000.5
+    }
 
     /// Returns two DateInRegion objects indicating the start and the end of the current weekend .
     ///

--- a/Sources/SwiftDate/DateInRegion.swift
+++ b/Sources/SwiftDate/DateInRegion.swift
@@ -252,6 +252,40 @@ public struct DateInRegion {
             self.init(newComponents)
     }
 
+    /**
+     Initialise a `DateInRegion` object from a julian day.
+     
+     - Parameters:
+     - fromJulianDay: the julian day from which to get the date
+     - region: region to set (optional)
+     */
+    public init(
+        fromJulianDay: Double,
+        region: Region? = nil) {
+        
+        let refDate = NSDate(timeIntervalSinceReferenceDate: 0)
+        let timeInterval = (fromJulianDay - refDate.julianDay()) * 86400.0
+        
+        self.init(absoluteTime: NSDate(timeIntervalSinceReferenceDate: timeInterval), region: region)
+    }
+
+    /**
+     Initialise a `DateInRegion` object from a modified julian day.
+     
+     - Parameters:
+     - fromModifiedJulianDay: the modified julian day from which to get the date
+     - region: region to set (optional)
+     */
+    public init(
+        fromModifiedJulianDay: Double,
+        region: Region? = nil) {
+        
+        let refDate = NSDate(timeIntervalSinceReferenceDate: 0)
+        let timeInterval = (fromModifiedJulianDay - refDate.modifiedJulianDay()) * 86400.0
+        
+        self.init(absoluteTime: NSDate(timeIntervalSinceReferenceDate: timeInterval), region: region)
+    }
+
 
     /// Initialize a new DateInRegion string from a specified date string, a given format and a
     /// destination region for the date

--- a/Sources/SwiftDate/NSDate+SwiftDate.swift
+++ b/Sources/SwiftDate/NSDate+SwiftDate.swift
@@ -501,7 +501,16 @@ extension NSDate {
     public var era: Int {
         return self.inRegion().era
     }
+    
+    /// Compute the julian day corresponding to the curren date. The julian day and its modified
+    /// version below are used as linear time stamps in astronomy. 
+    public func julianDay() -> Double {
+        return self.inRegion().julianDay()
+    }
 
+    public func modifiedJulianDay() -> Double {
+        return self.inRegion().modifiedJulianDay()
+    }
 
     /**
      Get the first day of the week in current self absolute time in calendar

--- a/Sources/SwiftDate/NSDate+SwiftDate.swift
+++ b/Sources/SwiftDate/NSDate+SwiftDate.swift
@@ -80,7 +80,21 @@ extension NSDate {
 
             self.init(timeIntervalSinceReferenceDate: dateInRegion.timeIntervalSinceReferenceDate)
     }
+    
+    public convenience init(
+        fromJulianDay: Double, region: Region? = nil) {
+        
+            let dateInRegion = DateInRegion(fromJulianDay: fromJulianDay, region: region)
+            self.init(timeIntervalSinceReferenceDate: dateInRegion.timeIntervalSinceReferenceDate)
+    }
 
+    public convenience init(
+        fromModifiedJulianDay: Double, region: Region? = nil) {
+        
+        let dateInRegion = DateInRegion(fromModifiedJulianDay: fromModifiedJulianDay, region: region)
+        self.init(timeIntervalSinceReferenceDate: dateInRegion.timeIntervalSinceReferenceDate)
+    }
+    
     public convenience init(components: NSDateComponents) {
         let dateInRegion = DateInRegion(components)
         let absoluteTime = dateInRegion.absoluteTime

--- a/Sources/SwiftDateTests/NSDateComponentPortTests.swift
+++ b/Sources/SwiftDateTests/NSDateComponentPortTests.swift
@@ -101,6 +101,20 @@ class NSDateComponentPortSpec: QuickSpec {
                 }
 
             }
+            
+            context("julianDays") {
+                
+                let date = NSDate(era: 1, year: 2016, month: 5, day: 20, hour: 22, minute: 19, second: 7, nanosecond: 87654321)
+
+                it("should report a valid julian day") {
+                    expect(date.julianDay()).to(beCloseTo(2457529.346609, within: 0.000001))
+                }
+
+                it("should report a valid modified julian day") {
+                    expect(date.modifiedJulianDay()).to(beCloseTo(57528.846609, within: 0.000001))
+                }
+
+            }
 
             context("component initialisation") {
 

--- a/XCode/Cartfile.resolved
+++ b/XCode/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v3.1.0"
-github "Quick/Quick" "v0.9.1"
+github "Quick/Nimble" "v4.0.1"
+github "Quick/Quick" "v0.9.2"


### PR DESCRIPTION
Hi. I am using a lot date conversions and SwiftDate is clearly the best framework for that. But I would be so glad it also contains support for Julian Days (which are linear "dates" used by astronomers worldwide). Of course, I could create my own extensions, but I thought it would be cool to have it here. I've added tests as well. I hope I've respected style and conventions as much as possible!
Thanks anyway for the great work.