### PR TITLE
Use POSIX for DateInRegion.toString when using ISO format

### DIFF
--- a/Sources/SwiftDate/DateInRegion+Formatter.swift
+++ b/Sources/SwiftDate/DateInRegion+Formatter.swift
@@ -90,7 +90,14 @@ public extension DateInRegion {
 			cachedFormatter.dateFormat = dateFormatString
 			cachedFormatter.timeZone = self.region.timeZone
 			cachedFormatter.calendar = self.region.calendar
-			cachedFormatter.locale = self.region.calendar.locale
+			
+            switch dateFormat {
+            case .ISO8601, .ISO8601Format:
+                cachedFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+            default:
+                cachedFormatter.locale = self.region.calendar.locale
+            }
+
 			let value = cachedFormatter.stringFromDate(self.absoluteTime!)
 			return value
 		}


### PR DESCRIPTION
When parsing ISO strings, DateInRegion correctly sets locale to POSIX. However, when writing ISO strings it does not set the locale to POSIX, resulting in the wrong format on some devices. This PR fixes this.