### PR TITLE
Change to public

### DIFF
--- a/Sources/SwiftDate/NSDateFormatter+SwiftDate.swift
+++ b/Sources/SwiftDate/NSDateFormatter+SwiftDate.swift
@@ -104,7 +104,7 @@ public enum DateFormat {
     case AltRSS							// Alt RSS Formatter
     case Extended						// Extended date Formatter
 
-    var formatString: String {
+    public var formatString: String {
         switch self {
         case .Custom(let format):		return format
         case .ISO8601Date:				return (ISO8601Type.Date).rawValue


### PR DESCRIPTION
Just a quick _improvement_.
When you're developing framework, and I consider `SwiftDate` as one, you have to explicitly define access to each element... Which kinda sucks.

So, I wanted to use `formatString` from `NSDateFormatter+SwiftDate` as I need to pass this format somewhere else in my app, but because `formatString` isn't marked as `public` I can't access it from my app. That's why I've created this PR.