### PR TITLE
SwiftDate.bundle file loading made generic

### DIFF
--- a/Sources/SwiftDate/DateFormatter.swift
+++ b/Sources/SwiftDate/DateFormatter.swift
@@ -133,11 +133,11 @@ public class DateFormatter {
 
     /// This is the bundle where the localized data is placed
     private lazy var bundle: Bundle? = {
-        var frameworkBundle = Bundle(identifier: "com.danielemagutti.SwiftDate")
+        var frameworkBundle = Bundle(for: DateFormatter.self)
 		if frameworkBundle == nil { frameworkBundle = Bundle.main }
 		if frameworkBundle == nil { return nil }
 		let path = NSURL(fileURLWithPath:
-            frameworkBundle!.resourcePath!).appendingPathComponent("SwiftDate.bundle")
+            frameworkBundle.resourcePath!).appendingPathComponent("SwiftDate.bundle")
         let bundle = Bundle(url: path!)
         return bundle
     }()

--- a/SwiftDate.podspec
+++ b/SwiftDate.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |spec|
   spec.tvos.deployment_target = '9.0'
   spec.requires_arc = true
   spec.module_name = 'SwiftDate'
+  spec.resources = 'Sources/SwiftDate/SwiftDate.bundle'
 end


### PR DESCRIPTION
Bundle file logic tweaked to avoid using bundler identifier.