### PR TITLE
Add 'Automatic' ProvisioningStyle to project file

### DIFF
--- a/XCode/SwiftDate.xcodeproj/project.pbxproj
+++ b/XCode/SwiftDate.xcodeproj/project.pbxproj
@@ -514,18 +514,22 @@
 				TargetAttributes = {
 					1FAA83911C79C6DA0084BAB6 = {
 						CreatedOnToolsVersion = 7.2.1;
+						ProvisioningStyle = Automatic;
 					};
 					1FAA839A1C79C6DA0084BAB6 = {
 						CreatedOnToolsVersion = 7.2.1;
 					};
 					90F1F3881C7F6AF500B22B90 = {
 						CreatedOnToolsVersion = 7.3;
+						ProvisioningStyle = Automatic;
 					};
 					90F1F3A91C7F6BB800B22B90 = {
 						CreatedOnToolsVersion = 7.3;
+						ProvisioningStyle = Automatic;
 					};
 					90F1F3C91C7F6BEE00B22B90 = {
 						CreatedOnToolsVersion = 7.3;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};


### PR DESCRIPTION
Frameworks should be set to `Automatic` ProvisioningStyle so that parent workspaces can control provisioning identites with Xcode 8.
Without this set, using `xcodebuild archive` will trip up if `PROVISIONING_PROFILE_SPECIFIER` has been set.