### PR TITLE
Migrated Tests to Swift 3 & fix for case were DateComponents doesn't return nil

### DIFF
--- a/Sources/SwiftDate/Date+SwiftDate.swift
+++ b/Sources/SwiftDate/Date+SwiftDate.swift
@@ -82,21 +82,21 @@ extension Date {
 
             self.init(timeIntervalSinceReferenceDate: dateInRegion.timeIntervalSinceReferenceDate)
     }
-    
+
     public init(
         fromJulianDay: Double, region: Region? = nil) {
-        
+
             let dateInRegion = DateInRegion(fromJulianDay: fromJulianDay, region: region)
             self.init(timeIntervalSinceReferenceDate: dateInRegion.timeIntervalSinceReferenceDate)
     }
 
     public init(
         fromModifiedJulianDay: Double, region: Region? = nil) {
-        
+
         let dateInRegion = DateInRegion(fromModifiedJulianDay: fromModifiedJulianDay, region: region)
         self.init(timeIntervalSinceReferenceDate: dateInRegion.timeIntervalSinceReferenceDate)
     }
-    
+
     public init(components: DateComponents) {
         let dateInRegion = DateInRegion(components)
         let absoluteTime = dateInRegion.absoluteTime
@@ -385,7 +385,7 @@ extension Date {
     public var monthName: String {
         return self.inRegion().monthName
     }
-	
+
 	/// Get the short month name component of the date in current region (use inRegion(...).shortMonthName to
 	/// get the month's short name component in specified time zone)
 	public var shortMonthName: String {
@@ -471,9 +471,9 @@ extension Date {
     public var era: Int {
         return self.inRegion().era
     }
-    
+
     /// Compute the julian day corresponding to the curren date. The julian day and its modified
-    /// version below are used as linear time stamps in astronomy. 
+    /// version below are used as linear time stamps in astronomy.
     public func julianDay() -> Double {
         return self.inRegion().julianDay()
     }

--- a/Sources/SwiftDate/DateComponents+SwiftDate.swift
+++ b/Sources/SwiftDate/DateComponents+SwiftDate.swift
@@ -119,10 +119,10 @@ extension DateComponents {
 public func | (lhs: DateComponents, rhs: DateComponents) -> DateComponents {
     var dc = DateComponents()
     for component in DateInRegion.componentFlagSet {
-        if let lhs_value = lhs.value(for: component) {
+        if let lhs_value = lhs.value(for: component), lhs_value != DateComponents.undefined {
             dc.setValue(lhs_value, for: component)
         }
-        if let rhs_value = rhs.value(for: component) {
+        if let rhs_value = rhs.value(for: component), rhs_value != DateComponents.undefined {
             dc.setValue(rhs_value, for: component)
         }
     }

--- a/Sources/SwiftDate/DateComponents+SwiftDate.swift
+++ b/Sources/SwiftDate/DateComponents+SwiftDate.swift
@@ -27,7 +27,7 @@ import Foundation
 //MARK: - Extension of Int To Manage Operations -
 
 extension DateComponents {
-    
+
     static var undefined: Int {
         return Int.max
     }
@@ -58,7 +58,7 @@ extension DateComponents {
     public func agoFromDate(_ refDate: Date!, in region: Region = Region.defaultRegion) -> Date {
         var dc = DateComponents()
         for component in DateInRegion.componentFlagSet {
-            if let value = self.value(for: component) {
+            if let value = self.value(for: component), value != DateComponents.undefined {
                 dc.setValue((value * -1), for: component)
             }
         }

--- a/Sources/SwiftDate/DateComponents+SwiftDate.swift
+++ b/Sources/SwiftDate/DateComponents+SwiftDate.swift
@@ -27,6 +27,10 @@ import Foundation
 //MARK: - Extension of Int To Manage Operations -
 
 extension DateComponents {
+    
+    static var undefined: Int {
+        return Int.max
+    }
 
     /**
      Create a new date from a specific date by adding self components
@@ -170,8 +174,8 @@ internal func sumDateComponents(lhs: DateComponents, rhs: DateComponents, sum: B
             continue // both are undefined, don't touch
         }
 
-        let checkedLeftValue = leftValue != Int.max ? leftValue : 0
-        let checkedRightValue = rightValue != Int.max ? rightValue : 0
+        let checkedLeftValue = leftValue != DateComponents.undefined ? leftValue : 0
+        let checkedRightValue = rightValue != DateComponents.undefined ? rightValue : 0
 
         let finalValue =  checkedLeftValue + (sum ? checkedRightValue : -checkedRightValue)
         newComponents.setValue(finalValue, for: component)

--- a/Sources/SwiftDate/DateComponents+SwiftDate.swift
+++ b/Sources/SwiftDate/DateComponents+SwiftDate.swift
@@ -164,15 +164,14 @@ internal func sumDateComponents(lhs: DateComponents, rhs: DateComponents, sum: B
     var newComponents = DateComponents()
     let components = DateInRegion.componentFlagSet
     for component in components {
-        let leftValue = lhs.value(for: component)
-        let rightValue = rhs.value(for: component)
 
-        guard leftValue != nil || rightValue != nil else {
+        guard let leftValue = lhs.value(for: component),
+            let rightValue = rhs.value(for: component) else {
             continue // both are undefined, don't touch
         }
 
-        let checkedLeftValue = leftValue ?? 0
-        let checkedRightValue = rightValue ?? 0
+        let checkedLeftValue = leftValue != Int.max ? leftValue : 0
+        let checkedRightValue = rightValue != Int.max ? rightValue : 0
 
         let finalValue =  checkedLeftValue + (sum ? checkedRightValue : -checkedRightValue)
         newComponents.setValue(finalValue, for: component)

--- a/Sources/SwiftDate/DateFormatter+SwiftDate.swift
+++ b/Sources/SwiftDate/DateFormatter+SwiftDate.swift
@@ -193,10 +193,9 @@ extension String {
         }
         return dateFormatter
     }
-	
+
 	/**
 	Return the value in seconds from a dotNet expressed date object
-	
 	- returns: an NSTimeInterval or nil if string cannot be parsed
 	*/
 	internal func dotNet_secondsFromString() -> TimeInterval? {

--- a/Sources/SwiftDate/DateInRegion+Components.swift
+++ b/Sources/SwiftDate/DateInRegion+Components.swift
@@ -212,7 +212,7 @@ extension DateInRegion {
 			return value
 		}!
     }
-	
+
 	/// Short month name of the date expressed in this region's timezone using region's locale
 	public var shortMonthName: String {
 		let cachedFormatter = sharedDateFormatter()
@@ -259,29 +259,29 @@ extension DateInRegion {
         // For other calendars:
         return calendar.dateComponents([.day, .month, .year], from: absoluteTime).isLeapMonth!
     }
-    
+
     /// The julian day corresponding to the current civil date. Note that it is often called Julian Date.
     /// But we prefer Jean Meeus reference textboox where he explains the julian day isn't a Date, but rather a Day.
-    /// The formula can be found in http://scienceworld.wolfram.com/astronomy/JulianDate.html 
+    /// The formula can be found in http://scienceworld.wolfram.com/astronomy/JulianDate.html
     /// It is valid between 1901 and 2099.
     ///
     /// - Returns the Julian Day of the date.
     ///
     public func julianDay() -> Double {
         let utc = self.inRegion(region: DateRegion(calendarName: .gregorian, timeZoneName: .gmt, localeName: .english))
-        
+
         let year = Double(utc.year)
         let month = Double(utc.month)
         let day = Double(utc.day)
         let hour = Double(utc.hour) + Double(utc.minute)/60.0 + (Double(utc.second)+Double(utc.nanosecond)/1e9)/3600.0
-        
+
         var jd = 367.0*year - floor( 7.0*( year+floor((month+9.0)/12.0))/4.0 )
         jd -= floor( 3.0*(floor( (year+(month-9.0)/7.0)/100.0 ) + 1.0)/4.0 )
         jd += floor(275.0*month/9.0) + day + 1721028.5 + hour/24.0
-        
+
         return jd
     }
-    
+
     /// Most popular variant of JD.
     ///
     /// - Returns the Modified Julain Day of the date.

--- a/Sources/SwiftDate/DateInRegion+Formatter.swift
+++ b/Sources/SwiftDate/DateInRegion+Formatter.swift
@@ -109,7 +109,7 @@ extension DateInRegion {
 			let tzOffsets = (self.timeZone.secondsFromGMT(for: self.absoluteTime) / 3600)
 			return (NSString(format: "/Date(%.0f%+03d00)/", milliseconds,tzOffsets) as String)
 		}
-		
+
 		// Other formatter styles
 		let cachedFormatter = sharedDateFormatter()
 		return cachedFormatter.beginSessionContext { (void) -> (String?) in
@@ -427,7 +427,7 @@ extension Calendar.Component {
         case .timeZone:          return 1 << 17
         }
     }
-    
+
     internal init?(rawValue: UInt) {
         switch rawValue {
         case Calendar.Component.era.rawValue:               self = .era

--- a/Sources/SwiftDate/DateInRegion+Operations.swift
+++ b/Sources/SwiftDate/DateInRegion+Operations.swift
@@ -129,7 +129,9 @@ public prefix func - (dateComponents: DateComponents) -> DateComponents {
     var result = DateComponents()
     for component in DateInRegion.componentFlagSet {
         if let value = dateComponents.value(for: component) {
-            result.setValue(-value, for: component)
+            if value != DateComponents.undefined {
+                result.setValue(-value, for: component)
+            }
         }
     }
     return result

--- a/Sources/SwiftDate/DateInRegion+Operations.swift
+++ b/Sources/SwiftDate/DateInRegion+Operations.swift
@@ -57,7 +57,7 @@ extension DateInRegion {
             minute: minutes,
             second: seconds,
             nanosecond: nanosecond,
-            weekOfYear: weekOfYear)
+            weekOfYear: weeks)
 
         let newDate = self.add(components)
         return newDate

--- a/Sources/SwiftDate/DateInRegion+Operations.swift
+++ b/Sources/SwiftDate/DateInRegion+Operations.swift
@@ -65,9 +65,9 @@ extension DateInRegion {
 
 	/**
 	Add components to an existing date in region instance
-	
+
 	- parameter components: components to add
-	
+
 	- returns: return a new DateInRegion
 	*/
     public func add(_ components: DateComponents) -> DateInRegion {

--- a/Sources/SwiftDate/DateInRegion.swift
+++ b/Sources/SwiftDate/DateInRegion.swift
@@ -67,7 +67,7 @@ public struct DateInRegion {
     /// If you want to assign a new value then you must assign it to a new instance of DateInRegion.
 	///
     public let absoluteTime: Date
-	
+
 	/// This method return an NSDate object which contains the absolute representation of datetime
 	/// in region specified timezone.
 	public var localAbsoluteDate: Date {
@@ -165,7 +165,7 @@ public struct DateInRegion {
             minute: minute ?? fromDate.minute,
             second: second ?? fromDate.second,
             nanosecond: nanosecond ?? fromDate.nanosecond)
-        
+
         self.init(newComponents)
     }
 
@@ -255,13 +255,13 @@ public struct DateInRegion {
             weekday: weekday,
             weekOfYear: weekOfYear,
             yearForWeekOfYear: yearForWeekOfYear)
-        
+
         self.init(newComponents)
     }
 
     /**
      Initialise a `DateInRegion` object from a julian day.
-     
+
      - Parameters:
      - fromJulianDay: the julian day from which to get the date
      - region: region to set (optional)
@@ -269,16 +269,15 @@ public struct DateInRegion {
     public init(
         fromJulianDay: Double,
         region: Region? = nil) {
-        
+
         let refDate = Date(timeIntervalSinceReferenceDate: 0)
         let timeInterval = (fromJulianDay - refDate.julianDay()) * 86400.0
-        
+
         self.init(absoluteTime: Date(timeIntervalSinceReferenceDate: timeInterval), region: region)
     }
 
     /**
      Initialise a `DateInRegion` object from a modified julian day.
-     
      - Parameters:
      - fromModifiedJulianDay: the modified julian day from which to get the date
      - region: region to set (optional)
@@ -286,10 +285,10 @@ public struct DateInRegion {
     public init(
         fromModifiedJulianDay: Double,
         region: Region? = nil) {
-        
+
         let refDate = Date(timeIntervalSinceReferenceDate: 0)
         let timeInterval = (fromModifiedJulianDay - refDate.modifiedJulianDay()) * 86400.0
-        
+
         self.init(absoluteTime: Date(timeIntervalSinceReferenceDate: timeInterval), region: region)
     }
 
@@ -314,7 +313,7 @@ public struct DateInRegion {
                 cFormatter.locale = region.locale
 
                 let parsedDate: Date?
-				
+
 				var stringWithTimeZone = dateString
 				if dateString.hasSuffix("Z") == true && dateString.contains(".") == false && dateString.contains("+") == false {
                     stringWithTimeZone = dateString.substring(to: dateString.index(dateString.endIndex, offsetBy: -1)) + "+0000"
@@ -346,7 +345,7 @@ public struct DateInRegion {
 					parsedDate = cFormatter.date(from: stringWithTimeZone)
 				case .dotNET:
 					guard let secondsInString = dateString.dotNet_secondsFromString() else { return nil }
-					
+
 					parsedDate = Date(timeIntervalSince1970: secondsInString)
 				}
 				return parsedDate

--- a/Sources/SwiftDate/Locale+SwiftDate.swift
+++ b/Sources/SwiftDate/Locale+SwiftDate.swift
@@ -47,7 +47,7 @@ public enum LocaleName: String {
 
     case current = "Current"
     case system = "System"
-    
+
     case afrikaans = "af"
     case afrikaansNamibia = "af_NA"
     case afrikaansSouthAfrica = "af_ZA"

--- a/Sources/SwiftDate/Region.swift
+++ b/Sources/SwiftDate/Region.swift
@@ -34,7 +34,7 @@ public typealias DateRegion = Region
 ///
 @available(*, introduced:2.0)
 public struct Region: Equatable {
-	
+
 	/// Define the default region to use when you avoid to pass a valid Region() as parameter inside the library itself.
 	/// Default region is composed by
 	public static var defaultRegion: Region = {
@@ -111,7 +111,7 @@ public struct Region: Equatable {
         let calendar = calendarName?.calendar ?? Calendar.current
         let timeZone = timeZoneName?.timeZone ?? NSTimeZone.default
         let locale = localeName?.locale ?? NSLocale.current
-        
+
         self.init(calendar: calendar, timeZone: timeZone, locale: locale)
     }
 
@@ -146,7 +146,7 @@ public func == (left: Region, right: Region) -> Bool {
     if left.calendar.identifier != right.calendar.identifier {
         return false
     }
-    
+
     if left.timeZone.identifier != right.timeZone.identifier {
         return false
     }

--- a/Sources/SwiftDateTests/DateInRegionComparisonTests.swift
+++ b/Sources/SwiftDateTests/DateInRegionComparisonTests.swift
@@ -18,7 +18,7 @@ class DateInRegionComparisonSpec: QuickSpec {
 
         describe("DateInRegionComparisons") {
 
-            let region = Region(calendarName: .Gregorian, timeZoneName: .AmericaParamaribo, localeName: .Dutch)
+            let region = Region(calendarName: .gregorian, timeZoneName: .americaParamaribo, localeName: .dutch)
             let date = DateInRegion(year: 2015, month: 12, day: 14, hour: 13, region: region)
 
             context("compareDates") {
@@ -27,63 +27,63 @@ class DateInRegionComparisonSpec: QuickSpec {
                     let date1 = date - 1.years
                     let date2 = date - 1.months
                     let date3 = date + 1.years
-                    expect(date.compareDate(date1, toUnitGranularity: .Year)) == NSComparisonResult.OrderedDescending
-                    expect(date.compareDate(date2, toUnitGranularity: .Year)) == NSComparisonResult.OrderedSame
-                    expect(date.compareDate(date3, toUnitGranularity: .Year)) == NSComparisonResult.OrderedAscending
+                    expect(date.compare(date: date1, toGranularity: .year)) == ComparisonResult.orderedDescending
+                    expect(date.compare(date: date2, toGranularity: .year)) == ComparisonResult.orderedSame
+                    expect(date.compare(date: date3, toGranularity: .year)) == ComparisonResult.orderedAscending
                 }
 
                 it("should report proper results for month granularity unit") {
                     let date1 = date - 1.months
                     let date2 = date + 1.weeks
                     let date3 = date + 1.months
-                    expect(date.compareDate(date1, toUnitGranularity: .Month)) == NSComparisonResult.OrderedDescending
-                    expect(date.compareDate(date2, toUnitGranularity: .Month)) == NSComparisonResult.OrderedSame
-                    expect(date.compareDate(date3, toUnitGranularity: .Month)) == NSComparisonResult.OrderedAscending
+                    expect(date.compare(date: date1, toGranularity: .month)) == ComparisonResult.orderedDescending
+                    expect(date.compare(date: date2, toGranularity: .month)) == ComparisonResult.orderedSame
+                    expect(date.compare(date: date3, toGranularity: .month)) == ComparisonResult.orderedAscending
                 }
 
                 it("should report proper results for week granularity unit") {
                     let date1 = date - 1.weeks
                     let date2 = date + 1.days
                     let date3 = date + 1.weeks
-                    expect(date.compareDate(date1, toUnitGranularity: .WeekOfYear)) == NSComparisonResult.OrderedDescending
-                    expect(date.compareDate(date2, toUnitGranularity: .WeekOfYear)) == NSComparisonResult.OrderedSame
-                    expect(date.compareDate(date3, toUnitGranularity: .WeekOfYear)) == NSComparisonResult.OrderedAscending
+                    expect(date.compare(date: date1, toGranularity: .weekOfYear)) == ComparisonResult.orderedDescending
+                    expect(date.compare(date: date2, toGranularity: .weekOfYear)) == ComparisonResult.orderedSame
+                    expect(date.compare(date: date3, toGranularity: .weekOfYear)) == ComparisonResult.orderedAscending
                 }
 
                 it("should report proper results for day granularity unit") {
                     let date1 = date - 1.days
                     let date2 = date + 1.hours
                     let date3 = date + 1.days
-                    expect(date.compareDate(date1, toUnitGranularity: .Day)) == NSComparisonResult.OrderedDescending
-                    expect(date.compareDate(date2, toUnitGranularity: .Day)) == NSComparisonResult.OrderedSame
-                    expect(date.compareDate(date3, toUnitGranularity: .Day)) == NSComparisonResult.OrderedAscending
+                    expect(date.compare(date: date1, toGranularity: .day)) == ComparisonResult.orderedDescending
+                    expect(date.compare(date: date2, toGranularity: .day)) == ComparisonResult.orderedSame
+                    expect(date.compare(date: date3, toGranularity: .day)) == ComparisonResult.orderedAscending
                 }
 
                 it("should report proper results for hour granularity unit") {
                     let date1 = date - 1.hours
                     let date2 = date + 1.minutes
                     let date3 = date + 1.hours
-                    expect(date.compareDate(date1, toUnitGranularity: .Hour)) == NSComparisonResult.OrderedDescending
-                    expect(date.compareDate(date2, toUnitGranularity: .Hour)) == NSComparisonResult.OrderedSame
-                    expect(date.compareDate(date3, toUnitGranularity: .Hour)) == NSComparisonResult.OrderedAscending
+                    expect(date.compare(date: date1, toGranularity: .hour)) == ComparisonResult.orderedDescending
+                    expect(date.compare(date: date2, toGranularity: .hour)) == ComparisonResult.orderedSame
+                    expect(date.compare(date: date3, toGranularity: .hour)) == ComparisonResult.orderedAscending
                 }
 
                 it("should report proper results for minute granularity unit") {
                     let date1 = date - 1.minutes
                     let date2 = date + 1.seconds
                     let date3 = date + 1.minutes
-                    expect(date.compareDate(date1, toUnitGranularity: .Minute)) == NSComparisonResult.OrderedDescending
-                    expect(date.compareDate(date2, toUnitGranularity: .Minute)) == NSComparisonResult.OrderedSame
-                    expect(date.compareDate(date3, toUnitGranularity: .Minute)) == NSComparisonResult.OrderedAscending
+                    expect(date.compare(date: date1, toGranularity: .minute)) == ComparisonResult.orderedDescending
+                    expect(date.compare(date: date2, toGranularity: .minute)) == ComparisonResult.orderedSame
+                    expect(date.compare(date: date3, toGranularity: .minute)) == ComparisonResult.orderedAscending
                 }
 
                 it("should report proper results for second granularity unit") {
                     let date1 = date - 1.seconds
                     let date2 = date + 100000.nanoseconds
                     let date3 = date + 1.seconds
-                    expect(date.compareDate(date1, toUnitGranularity: .Second)) == NSComparisonResult.OrderedDescending
-                    expect(date.compareDate(date2, toUnitGranularity: .Second)) == NSComparisonResult.OrderedSame
-                    expect(date.compareDate(date3, toUnitGranularity: .Second)) == NSComparisonResult.OrderedAscending
+                    expect(date.compare(date: date1, toGranularity: .second)) == ComparisonResult.orderedDescending
+                    expect(date.compare(date: date2, toGranularity: .second)) == ComparisonResult.orderedSame
+                    expect(date.compare(date: date3, toGranularity: .second)) == ComparisonResult.orderedAscending
                 }
             }
 
@@ -99,8 +99,8 @@ class DateInRegionComparisonSpec: QuickSpec {
                 }
 
                 it("should report false when comparing to a date with different region") {
-                    let region = Region(localeName: .ItalianItaly)
-                    let date2 = date.inRegion(region)
+                    let region = Region(localeName: .italianItaly)
+                    let date2 = date.inRegion(region: region)
                     expect(date.isEqualToDate(date2)) == false
                 }
 
@@ -113,70 +113,70 @@ class DateInRegionComparisonSpec: QuickSpec {
                     let date1 = date - 1.years
                     let date2 = date - 1.months
                     let date3 = date + 1.years
-                    let unit = NSCalendarUnit.Year
-                    expect(date.isIn(unit, ofDate: date1)) == false
-                    expect(date.isIn(unit, ofDate: date2)) == true
-                    expect(date.isIn(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.year
+                    expect(date.isIn(component: unit, of: date1)) == false
+                    expect(date.isIn(component: unit, of: date2)) == true
+                    expect(date.isIn(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for month granularity unit") {
                     let date1 = date - 1.months
                     let date2 = date + 1.weeks
                     let date3 = date + 1.months
-                    let unit = NSCalendarUnit.Month
-                    expect(date.isIn(unit, ofDate: date1)) == false
-                    expect(date.isIn(unit, ofDate: date2)) == true
-                    expect(date.isIn(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.month
+                    expect(date.isIn(component: unit, of: date1)) == false
+                    expect(date.isIn(component: unit, of: date2)) == true
+                    expect(date.isIn(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for week granularity unit") {
                     let date1 = date - 1.weeks
                     let date2 = date + 1.days
                     let date3 = date + 1.weeks
-                    let unit = NSCalendarUnit.WeekOfYear
-                    expect(date.isIn(unit, ofDate: date1)) == false
-                    expect(date.isIn(unit, ofDate: date2)) == true
-                    expect(date.isIn(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.weekOfYear
+                    expect(date.isIn(component: unit, of: date1)) == false
+                    expect(date.isIn(component: unit, of: date2)) == true
+                    expect(date.isIn(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for day granularity unit") {
                     let date1 = date - 1.days
                     let date2 = date + 1.hours
                     let date3 = date + 1.days
-                    let unit = NSCalendarUnit.Day
-                    expect(date.isIn(unit, ofDate: date1)) == false
-                    expect(date.isIn(unit, ofDate: date2)) == true
-                    expect(date.isIn(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.day
+                    expect(date.isIn(component: unit, of: date1)) == false
+                    expect(date.isIn(component: unit, of: date2)) == true
+                    expect(date.isIn(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for hour granularity unit") {
                     let date1 = date - 1.hours
                     let date2 = date + 1.minutes
                     let date3 = date + 1.hours
-                    let unit = NSCalendarUnit.Hour
-                    expect(date.isIn(unit, ofDate: date1)) == false
-                    expect(date.isIn(unit, ofDate: date2)) == true
-                    expect(date.isIn(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.hour
+                    expect(date.isIn(component: unit, of: date1)) == false
+                    expect(date.isIn(component: unit, of: date2)) == true
+                    expect(date.isIn(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for minute granularity unit") {
                     let date1 = date - 1.minutes
                     let date2 = date + 1.seconds
                     let date3 = date + 1.minutes
-                    let unit = NSCalendarUnit.Minute
-                    expect(date.isIn(unit, ofDate: date1)) == false
-                    expect(date.isIn(unit, ofDate: date2)) == true
-                    expect(date.isIn(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.minute
+                    expect(date.isIn(component: unit, of: date1)) == false
+                    expect(date.isIn(component: unit, of: date2)) == true
+                    expect(date.isIn(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for second granularity unit") {
                     let date1 = date - 1.seconds
                     let date2 = date + 100000.nanoseconds
                     let date3 = date + 1.seconds
-                    let unit = NSCalendarUnit.Second
-                    expect(date.isIn(unit, ofDate: date1)) == false
-                    expect(date.isIn(unit, ofDate: date2)) == true
-                    expect(date.isIn(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.second
+                    expect(date.isIn(component: unit, of: date1)) == false
+                    expect(date.isIn(component: unit, of: date2)) == true
+                    expect(date.isIn(component: unit, of: date3)) == false
                 }
             }
 
@@ -186,70 +186,70 @@ class DateInRegionComparisonSpec: QuickSpec {
                     let date1 = date - 1.years
                     let date2 = date - 1.months
                     let date3 = date + 1.years
-                    let unit = NSCalendarUnit.Year
-                    expect(date.isBefore(unit, ofDate: date1)) == false
-                    expect(date.isBefore(unit, ofDate: date2)) == false
-                    expect(date.isBefore(unit, ofDate: date3)) == true
+                    let unit = Calendar.Component.year
+                    expect(date.isBefore(component: unit, of: date1)) == false
+                    expect(date.isBefore(component: unit, of: date2)) == false
+                    expect(date.isBefore(component: unit, of: date3)) == true
                 }
 
                 it("should report proper results for month granularity unit") {
                     let date1 = date - 1.months
                     let date2 = date + 1.weeks
                     let date3 = date + 1.months
-                    let unit = NSCalendarUnit.Month
-                    expect(date.isBefore(unit, ofDate: date1)) == false
-                    expect(date.isBefore(unit, ofDate: date2)) == false
-                    expect(date.isBefore(unit, ofDate: date3)) == true
+                    let unit = Calendar.Component.month
+                    expect(date.isBefore(component: unit, of: date1)) == false
+                    expect(date.isBefore(component: unit, of: date2)) == false
+                    expect(date.isBefore(component: unit, of: date3)) == true
                 }
 
                 it("should report proper results for week granularity unit") {
                     let date1 = date - 1.weeks
                     let date2 = date + 1.days
                     let date3 = date + 1.weeks
-                    let unit = NSCalendarUnit.WeekOfYear
-                    expect(date.isBefore(unit, ofDate: date1)) == false
-                    expect(date.isBefore(unit, ofDate: date2)) == false
-                    expect(date.isBefore(unit, ofDate: date3)) == true
+                    let unit = Calendar.Component.weekOfYear
+                    expect(date.isBefore(component: unit, of: date1)) == false
+                    expect(date.isBefore(component: unit, of: date2)) == false
+                    expect(date.isBefore(component: unit, of: date3)) == true
                 }
 
                 it("should report proper results for day granularity unit") {
                     let date1 = date - 1.days
                     let date2 = date + 1.hours
                     let date3 = date + 1.days
-                    let unit = NSCalendarUnit.Day
-                    expect(date.isBefore(unit, ofDate: date1)) == false
-                    expect(date.isBefore(unit, ofDate: date2)) == false
-                    expect(date.isBefore(unit, ofDate: date3)) == true
+                    let unit = Calendar.Component.day
+                    expect(date.isBefore(component: unit, of: date1)) == false
+                    expect(date.isBefore(component: unit, of: date2)) == false
+                    expect(date.isBefore(component: unit, of: date3)) == true
                 }
 
                 it("should report proper results for hour granularity unit") {
                     let date1 = date - 1.hours
                     let date2 = date + 1.minutes
                     let date3 = date + 1.hours
-                    let unit = NSCalendarUnit.Hour
-                    expect(date.isBefore(unit, ofDate: date1)) == false
-                    expect(date.isBefore(unit, ofDate: date2)) == false
-                    expect(date.isBefore(unit, ofDate: date3)) == true
+                    let unit = Calendar.Component.hour
+                    expect(date.isBefore(component: unit, of: date1)) == false
+                    expect(date.isBefore(component: unit, of: date2)) == false
+                    expect(date.isBefore(component: unit, of: date3)) == true
                 }
 
                 it("should report proper results for minute granularity unit") {
                     let date1 = date - 1.minutes
                     let date2 = date + 1.seconds
                     let date3 = date + 1.minutes
-                    let unit = NSCalendarUnit.Minute
-                    expect(date.isBefore(unit, ofDate: date1)) == false
-                    expect(date.isBefore(unit, ofDate: date2)) == false
-                    expect(date.isBefore(unit, ofDate: date3)) == true
+                    let unit = Calendar.Component.minute
+                    expect(date.isBefore(component: unit, of: date1)) == false
+                    expect(date.isBefore(component: unit, of: date2)) == false
+                    expect(date.isBefore(component: unit, of: date3)) == true
                 }
 
                 it("should report proper results for second granularity unit") {
                     let date1 = date - 1.seconds
                     let date2 = date + 100000.nanoseconds
                     let date3 = date + 1.seconds
-                    let unit = NSCalendarUnit.Second
-                    expect(date.isBefore(unit, ofDate: date1)) == false
-                    expect(date.isBefore(unit, ofDate: date2)) == false
-                    expect(date.isBefore(unit, ofDate: date3)) == true
+                    let unit = Calendar.Component.second
+                    expect(date.isBefore(component: unit, of: date1)) == false
+                    expect(date.isBefore(component: unit, of: date2)) == false
+                    expect(date.isBefore(component: unit, of: date3)) == true
                 }
             }
 
@@ -259,70 +259,70 @@ class DateInRegionComparisonSpec: QuickSpec {
                     let date1 = date - 1.years
                     let date2 = date - 1.months
                     let date3 = date + 1.years
-                    let unit = NSCalendarUnit.Year
-                    expect(date.isAfter(unit, ofDate: date1)) == true
-                    expect(date.isAfter(unit, ofDate: date2)) == false
-                    expect(date.isAfter(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.year
+                    expect(date.isAfter(component: unit, of: date1)) == true
+                    expect(date.isAfter(component: unit, of: date2)) == false
+                    expect(date.isAfter(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for month granularity unit") {
                     let date1 = date - 1.months
                     let date2 = date + 1.weeks
                     let date3 = date + 1.months
-                    let unit = NSCalendarUnit.Month
-                    expect(date.isAfter(unit, ofDate: date1)) == true
-                    expect(date.isAfter(unit, ofDate: date2)) == false
-                    expect(date.isAfter(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.month
+                    expect(date.isAfter(component: unit, of: date1)) == true
+                    expect(date.isAfter(component: unit, of: date2)) == false
+                    expect(date.isAfter(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for week granularity unit") {
                     let date1 = date - 1.weeks
                     let date2 = date + 1.days
                     let date3 = date + 1.weeks
-                    let unit = NSCalendarUnit.WeekOfYear
-                    expect(date.isAfter(unit, ofDate: date1)) == true
-                    expect(date.isAfter(unit, ofDate: date2)) == false
-                    expect(date.isAfter(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.weekOfYear
+                    expect(date.isAfter(component: unit, of: date1)) == true
+                    expect(date.isAfter(component: unit, of: date2)) == false
+                    expect(date.isAfter(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for day granularity unit") {
                     let date1 = date - 1.days
                     let date2 = date + 1.hours
                     let date3 = date + 1.days
-                    let unit = NSCalendarUnit.Day
-                    expect(date.isAfter(unit, ofDate: date1)) == true
-                    expect(date.isAfter(unit, ofDate: date2)) == false
-                    expect(date.isAfter(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.day
+                    expect(date.isAfter(component: unit, of: date1)) == true
+                    expect(date.isAfter(component: unit, of: date2)) == false
+                    expect(date.isAfter(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for hour granularity unit") {
                     let date1 = date - 1.hours
                     let date2 = date + 1.minutes
                     let date3 = date + 1.hours
-                    let unit = NSCalendarUnit.Hour
-                    expect(date.isAfter(unit, ofDate: date1)) == true
-                    expect(date.isAfter(unit, ofDate: date2)) == false
-                    expect(date.isAfter(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.hour
+                    expect(date.isAfter(component: unit, of: date1)) == true
+                    expect(date.isAfter(component: unit, of: date2)) == false
+                    expect(date.isAfter(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for minute granularity unit") {
                     let date1 = date - 1.minutes
                     let date2 = date + 1.seconds
                     let date3 = date + 1.minutes
-                    let unit = NSCalendarUnit.Minute
-                    expect(date.isAfter(unit, ofDate: date1)) == true
-                    expect(date.isAfter(unit, ofDate: date2)) == false
-                    expect(date.isAfter(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.minute
+                    expect(date.isAfter(component: unit, of: date1)) == true
+                    expect(date.isAfter(component: unit, of: date2)) == false
+                    expect(date.isAfter(component: unit, of: date3)) == false
                 }
 
                 it("should report proper results for second granularity unit") {
                     let date1 = date - 1.seconds
                     let date2 = date + 100000.nanoseconds
                     let date3 = date + 1.seconds
-                    let unit = NSCalendarUnit.Second
-                    expect(date.isAfter(unit, ofDate: date1)) == true
-                    expect(date.isAfter(unit, ofDate: date2)) == false
-                    expect(date.isAfter(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.second
+                    expect(date.isAfter(component: unit, of: date1)) == true
+                    expect(date.isAfter(component: unit, of: date2)) == false
+                    expect(date.isAfter(component: unit, of: date3)) == false
                 }
             }
 
@@ -334,22 +334,22 @@ class DateInRegionComparisonSpec: QuickSpec {
                 }
 
                 it("should report true for today at midnight") {
-                    let date = DateInRegion().startOf(.Day)
+                    let date = DateInRegion().startOf(component: .day)
                     expect(date.isInToday()) == true
                 }
 
                 it("should report true for today just before next midnight") {
-                    let date = DateInRegion().endOf(.Day)
+                    let date = DateInRegion().endOf(component: .day)
                     expect(date.isInToday()) == true
                 }
 
                 it("should report false for tomorrow at midnight") {
-                    let date = (DateInRegion() + 1.days).startOf(.Day)
+                    let date = (DateInRegion() + 1.days).startOf(component: .day)
                     expect(date.isInToday()) == false
                 }
 
                 it("should report false just before last midnight") {
-                    let date = (DateInRegion() - 1.days).endOf(.Day)
+                    let date = (DateInRegion() - 1.days).endOf(component: .day)
                     expect(date.isInToday()) == false
                 }
 
@@ -368,22 +368,22 @@ class DateInRegionComparisonSpec: QuickSpec {
                 }
 
                 it("should report true for yesterday at midnight") {
-                    let date = (DateInRegion() - 1.days).startOf(.Day)
+                    let date = (DateInRegion() - 1.days).startOf(component: .day)
                     expect(date.isInYesterday()) == true
                 }
 
                 it("should report true for yesterday just before next midnight") {
-                    let date = (DateInRegion() - 1.days).endOf(.Day)
+                    let date = (DateInRegion() - 1.days).endOf(component: .day)
                     expect(date.isInYesterday()) == true
                 }
 
                 it("should report false for today at midnight") {
-                    let date = DateInRegion().startOf(.Day)
+                    let date = DateInRegion().startOf(component: .day)
                     expect(date.isInYesterday()) == false
                 }
 
                 it("should report false just yesterday before last midnight") {
-                    let date = (DateInRegion() - 2.days).endOf(.Day)
+                    let date = (DateInRegion() - 2.days).endOf(component: .day)
                     expect(date.isInYesterday()) == false
                 }
 
@@ -403,22 +403,22 @@ class DateInRegionComparisonSpec: QuickSpec {
                 }
 
                 it("should report true for tomorrow at midnight") {
-                    let date = (DateInRegion() + 1.days).startOf(.Day)
+                    let date = (DateInRegion() + 1.days).startOf(component: .day)
                     expect(date.isInTomorrow()) == true
                 }
 
                 it("should report true for tomorrow just before next midnight") {
-                    let date = (DateInRegion() + 1.days).endOf(.Day)
+                    let date = (DateInRegion() + 1.days).endOf(component: .day)
                     expect(date.isInTomorrow()) == true
                 }
 
                 it("should report false for the day after tomorrow at midnight") {
-                    let date = (DateInRegion() + 2.days).startOf(.Day)
+                    let date = (DateInRegion() + 2.days).startOf(component: .day)
                     expect(date.isInTomorrow()) == false
                 }
 
                 it("should report false just tomorrow before last midnight") {
-                    let date = DateInRegion().endOf(.Day)
+                    let date = DateInRegion().endOf(component: .day)
                     expect(date.isInTomorrow()) == false
                 }
 

--- a/Sources/SwiftDateTests/DateInRegionComponentPortTests.swift
+++ b/Sources/SwiftDateTests/DateInRegionComponentPortTests.swift
@@ -18,9 +18,9 @@ class DateInRegionComponentPortSpec: QuickSpec {
 
         describe("DateInRegionComponentPort") {
 
-            let newYork = Region(calendarName: .Gregorian, timeZoneName: .AmericaNewYork, localeName: .EnglishUnitedStates)
-            let amsterdam = Region(calendarName: .Gregorian, timeZoneName: .EuropeAmsterdam, localeName: .DutchNetherlands)
-            let utc = Region(calendarName: .Gregorian, timeZoneName: .Gmt, localeName: .English)
+            let newYork = Region(calendarName: .gregorian, timeZoneName: .americaNewYork, localeName: .englishUnitedStates)
+            let amsterdam = Region(calendarName: .gregorian, timeZoneName: .europeAmsterdam, localeName: .dutchNetherlands)
+            let utc = Region(calendarName: .gregorian, timeZoneName: .gmt, localeName: .english)
 
             context("valueForComponentYMD") {
 
@@ -28,35 +28,35 @@ class DateInRegionComponentPortSpec: QuickSpec {
                 let date = DateInRegion(era: 1, year: 2002, month: 3, day: 4, hour: 5, minute: 6, second: 7, nanosecond: 87654321, region: region)
 
                 it("should report a valid era") {
-                    expect(date.valueForComponent(.Era)) == 1
+                    expect(date.value(for: .era)) == 1
                 }
 
                 it("should report a valid year") {
-                    expect(date.valueForComponent(.Year)) == 2002
+                    expect(date.value(for: .year)) == 2002
                 }
 
                 it("should report a valid month") {
-                    expect(date.valueForComponent(.Month)) == 3
+                    expect(date.value(for: .month)) == 3
                 }
 
                 it("should report a valid day") {
-                    expect(date.valueForComponent(.Day)) == 4
+                    expect(date.value(for: .day)) == 4
                 }
 
                 it("should report a valid hour") {
-                    expect(date.valueForComponent(.Hour)) == 5
+                    expect(date.value(for: .hour)) == 5
                 }
 
                 it("should report a valid minute") {
-                    expect(date.valueForComponent(.Minute)) == 6
+                    expect(date.value(for: .minute)) == 6
                 }
 
                 it("should report a valid second") {
-                    expect(date.valueForComponent(.Second)) == 7
+                    expect(date.value(for: .second)) == 7
                 }
 
                 it("should report a valid nanosecond") {
-                    expect(date.valueForComponent(.Nanosecond)).to(beCloseTo(87654321, within: 10))
+                    expect(date.value(for: .nanosecond)).to(beCloseTo(87654321, within: 10))
                 }
 
             }
@@ -67,35 +67,35 @@ class DateInRegionComponentPortSpec: QuickSpec {
                 let date = DateInRegion(era: 1, yearForWeekOfYear: 2, weekOfYear: 3, weekday: 4, region: region)
 
                 it("should report a valid era") {
-                    expect(date.valueForComponent(.Era)) == 1
+                    expect(date.value(for: .era)) == 1
                 }
 
                 it("should report a valid yearForWeekOfYear") {
-                    expect(date.valueForComponent(.YearForWeekOfYear)) == 2
+                    expect(date.value(for: .yearForWeekOfYear)) == 2
                 }
 
                 it("should report a valid weekOfYear") {
-                    expect(date.valueForComponent(.WeekOfYear)) == 3
+                    expect(date.value(for: .weekOfYear)) == 3
                 }
 
                 it("should report a valid weekday") {
-                    expect(date.valueForComponent(.Weekday)) == 4
+                    expect(date.value(for: .weekday)) == 4
                 }
 
                 it("should report a valid hour") {
-                    expect(date.valueForComponent(.Hour)) == 0
+                    expect(date.value(for: .hour)) == 0
                 }
 
                 it("should report a valid minute") {
-                    expect(date.valueForComponent(.Minute)) == 0
+                    expect(date.value(for: .minute)) == 0
                 }
 
                 it("should report a valid second") {
-                    expect(date.valueForComponent(.Second)) == 0
+                    expect(date.value(for: .second)) == 0
                 }
 
                 it("should report a valid nanosecond") {
-                    expect(date.valueForComponent(.Nanosecond)) == 0
+                    expect(date.value(for: .nanosecond)) == 0
                 }
 
             }
@@ -151,7 +151,7 @@ class DateInRegionComponentPortSpec: QuickSpec {
                 }
 
                 it("should return a date of 0001-01-01 00:00:00.000 in the default region for component initialisation") {
-                    let components = NSDateComponents()
+                    let components = DateComponents()
                     let date = DateInRegion(components)
 
                     expect(date.year) == 1
@@ -217,7 +217,7 @@ class DateInRegionComponentPortSpec: QuickSpec {
             context("Next weekend") {
 
                 let expectedStartDate = DateInRegion(year: 2015, month: 11, day: 7, region: amsterdam)
-                let expectedEndDate = (expectedStartDate + 1.days).endOf(.Day)
+                let expectedEndDate = (expectedStartDate + 1.days).endOf(component: .day)
 
                 it("should return next weekend on Friday") {
                     let date = DateInRegion(year: 2015, month: 11, day: 6, region: amsterdam)
@@ -287,7 +287,7 @@ class DateInRegionComponentPortSpec: QuickSpec {
             context("Previous weekend") {
 
                 let expectedStartDate = DateInRegion(year: 2015, month: 10, day: 31, region: amsterdam)
-                let expectedEndDate = (expectedStartDate + 1.days).endOf(.Day)
+                let expectedEndDate = (expectedStartDate + 1.days).endOf(component: .day)
 
 
                 it("should return last week's weekend on Sunday") {
@@ -357,7 +357,7 @@ class DateInRegionComponentPortSpec: QuickSpec {
             context("This weekend") {
 
                 let expectedStartDate = DateInRegion(year: 2016, month: 2, day: 20, region: amsterdam)
-                let expectedEndDate = (expectedStartDate + 1.days).endOf(.Day)
+                let expectedEndDate = (expectedStartDate + 1.days).endOf(component: .day)
 
 
                 it("should return this weekend on Sunday") {
@@ -399,19 +399,19 @@ class DateInRegionComponentPortSpec: QuickSpec {
                 //                it("should return error if no weekend in calendar") {
                 //
                 //
-                //                    for calendarName in [NSCalendarIdentifierGregorian,
-                //                        NSCalendarIdentifierBuddhist, NSCalendarIdentifierChinese,
-                //                        NSCalendarIdentifierCoptic, NSCalendarIdentifierEthiopicAmeteMihret,
-                //                        NSCalendarIdentifierEthiopicAmeteAlem, NSCalendarIdentifierHebrew,
-                //                        NSCalendarIdentifierISO8601, NSCalendarIdentifierIndian,
-                //                        NSCalendarIdentifierIslamic, NSCalendarIdentifierIslamicCivil,
-                //                        NSCalendarIdentifierJapanese, NSCalendarIdentifierPersian,
-                //                        NSCalendarIdentifierRepublicOfChina, NSCalendarIdentifierIslamicTabular,
-                //                        NSCalendarIdentifierIslamicUmmAlQura] {
+                //                    for calendarName in [CalendarIdentifierGregorian,
+                //                        CalendarIdentifierBuddhist, CalendarIdentifierChinese,
+                //                        CalendarIdentifierCoptic, CalendarIdentifierEthiopicAmeteMihret,
+                //                        CalendarIdentifierEthiopicAmeteAlem, CalendarIdentifierHebrew,
+                //                        CalendarIdentifierISO8601, CalendarIdentifierIndian,
+                //                        CalendarIdentifierIslamic, CalendarIdentifierIslamicCivil,
+                //                        CalendarIdentifierJapanese, CalendarIdentifierPersian,
+                //                        CalendarIdentifierRepublicOfChina, CalendarIdentifierIslamicTabular,
+                //                        CalendarIdentifierIslamicUmmAlQura] {
                 //                        print(calendarName)
-                //                        let calendar = NSCalendar(calendarIdentifier: calendarName)!
-                //                        for localeName in NSLocale.availableLocaleIdentifiers() {
-                //                            let locale = NSLocale(localeIdentifier: localeName)
+                //                        let calendar = Calendar(identifier: calendarName)!
+                //                        for localeName in Locale.availableLocaleIdentifiers() {
+                //                            let locale = Locale(localeIdentifier: localeName)
                 //                            let region = Region(calendar: calendar, locale: locale)
                 //                            let date = DateInRegion(region: region)
                 //                            let weekend = date.nextWeekend()

--- a/Sources/SwiftDateTests/DateInRegionEquationsTests.swift
+++ b/Sources/SwiftDateTests/DateInRegionEquationsTests.swift
@@ -16,8 +16,8 @@ class DateInRegionEquationsTests: QuickSpec {
 
         describe("DateInRegionEquations") {
 
-            let amsterdam = Region(calendarName: .Gregorian, timeZoneName: .EuropeAmsterdam, localeName: .DutchNetherlands)
-            let shanghai = Region(calendarName: .Chinese, timeZoneName: .AsiaShanghai, localeName: .ChineseChina)
+            let amsterdam = Region(calendarName: .gregorian, timeZoneName: .europeAmsterdam, localeName: .dutchNetherlands)
+            let shanghai = Region(calendarName: .chinese, timeZoneName: .asiaShanghai, localeName: .chineseChina)
 
             it("should return true for equating a different object with the same properties") {
                 let date1 = DateInRegion(year: 1999, month: 12, day: 31)

--- a/Sources/SwiftDateTests/DateInRegionHashableTests.swift
+++ b/Sources/SwiftDateTests/DateInRegionHashableTests.swift
@@ -14,8 +14,8 @@ class DateInRegionHashableTests: QuickSpec {
 
     override func spec() {
 
-        let netherlands = Region(calendarName: .Gregorian, timeZoneName: .EuropeAmsterdam, localeName: .DutchNetherlands)
-        let utc = Region(calendarName: .Gregorian, timeZoneName: .Gmt, localeName: .English)
+        let netherlands = Region(calendarName: .gregorian, timeZoneName: .europeAmsterdam, localeName: .dutchNetherlands)
+        let utc = Region(calendarName: .gregorian, timeZoneName: .gmt, localeName: .english)
 
         describe("DateInRegionHashable") {
 
@@ -40,7 +40,7 @@ class DateInRegionHashableTests: QuickSpec {
             }
 
             it("should return an unequal hash for a different time zone value") {
-                let date = NSDate()
+                let date = Date()
                 let date1 = DateInRegion(absoluteTime: date, region: netherlands)
                 let date2 = DateInRegion(absoluteTime: date, region: utc)
 

--- a/Sources/SwiftDateTests/DateInRegionOperationsTests.swift
+++ b/Sources/SwiftDateTests/DateInRegionOperationsTests.swift
@@ -18,7 +18,7 @@ class DateInRegionOperationsSpec: QuickSpec {
 
         describe("DateInRegionOperations") {
 
-            let region = Region(calendarName: .Gregorian, timeZoneName: .AmericaParamaribo, localeName: .Dutch)
+            let region = Region(calendarName: .gregorian, timeZoneName: .americaParamaribo, localeName: .dutch)
             let date = DateInRegion(year: 2015, month: 12, day: 14, hour: 13, region: region)
 
             context("add with components") {
@@ -35,7 +35,7 @@ class DateInRegionOperationsSpec: QuickSpec {
             context("add with dictionary") {
 
                 it("adds with a day") {
-                    expect(date.add(components: [NSCalendarUnit.Day: 1])) == date + 1.days
+                    expect(date.add(components: [Calendar.Component.day: 1])) == date + 1.days
                 }
             }
         }

--- a/Sources/SwiftDateTests/DateInRegionTests.swift
+++ b/Sources/SwiftDateTests/DateInRegionTests.swift
@@ -18,20 +18,20 @@ class DateInRegionSpec: QuickSpec {
 
     override func spec() {
 
-        let newYork = Region(calendarName: .Gregorian, timeZoneName: .AmericaNewYork, localeName: .EnglishUnitedStates)
-        let amsterdam = Region(calendarName: .Gregorian, timeZoneName: .EuropeAmsterdam, localeName: .DutchNetherlands)
-        let rome = Region(calendarName: .Gregorian, timeZoneName: .EuropeRome, localeName: .ItalianItaly)
-        let jerusalem = Region(calendarName: .Hebrew, timeZoneName: .AsiaJerusalem, localeName: .EnglishIsrael)
-        let bangkok = Region(calendarName: .Buddhist, timeZoneName: .AsiaBangkok, localeName: .ThaiThailand)
-        let utc = Region(calendarName: .Gregorian, timeZoneName: .Gmt, localeName: .English)
+        let newYork = Region(calendarName: .gregorian, timeZoneName: .americaNewYork, localeName: .englishUnitedStates)
+        let amsterdam = Region(calendarName: .gregorian, timeZoneName: .europeAmsterdam, localeName: .dutchNetherlands)
+        let rome = Region(calendarName: .gregorian, timeZoneName: .europeRome, localeName: .italianItaly)
+        let jerusalem = Region(calendarName: .hebrew, timeZoneName: .asiaJerusalem, localeName: .englishIsrael)
+        let bangkok = Region(calendarName: .buddhist, timeZoneName: .asiaBangkok, localeName: .thaiThailand)
+        let utc = Region(calendarName: .gregorian, timeZoneName: .gmt, localeName: .english)
 
         describe("DateInRegion") {
 
             context("DateInRegion, region initialisation") {
 
                 it("should have the default time zone in the current calendar") {
-                    let expectedTimeZone = NSTimeZone.defaultTimeZone()
-                    expect(NSCalendar.currentCalendar().timeZone) == expectedTimeZone
+                    let expectedTimeZone = NSTimeZone.default
+                    expect(Calendar.current.timeZone) == expectedTimeZone
                 }
 
                 it("should have the default region as default") {
@@ -49,9 +49,9 @@ class DateInRegionSpec: QuickSpec {
 
                 it("should return the current date") {
                     let jhDate = DateInRegion(region: amsterdam)
-                    let nsDate = NSDate()
+                    let nsDate = Date()
 
-                    let expectedInterval = NSTimeInterval(Double(nsDate.timeIntervalSinceReferenceDate))
+                    let expectedInterval = TimeInterval(Double(nsDate.timeIntervalSinceReferenceDate))
                     expect(jhDate.timeIntervalSinceReferenceDate) ≈ (expectedInterval, 1)
                 }
 
@@ -62,16 +62,16 @@ class DateInRegionSpec: QuickSpec {
                 }
 
                 it("should return the specified date") {
-                    let calendar = NSCalendar(identifier: NSCalendarIdentifierJapanese)!
-                    let components = NSDateComponents()
+                    let calendar = Calendar(identifier: Calendar.Identifier.japanese)
+                    var components = DateComponents()
                     components.year = 2345
                     components.month = 12
                     components.day = 5
-                    let nsDate = calendar.dateFromComponents(components)!
+                    let nsDate = calendar.date(from: components as DateComponents)!
 
                     let jhDate = DateInRegion(absoluteTime: nsDate, region: amsterdam)
 
-                    let expectedInterval = NSTimeInterval(Double(nsDate.timeIntervalSinceReferenceDate))
+                    let expectedInterval = TimeInterval(Double(nsDate.timeIntervalSinceReferenceDate))
                     expect(jhDate.timeIntervalSinceReferenceDate) == expectedInterval
                 }
 
@@ -91,16 +91,16 @@ class DateInRegionSpec: QuickSpec {
                     expect(components.minute) == 0
                     expect(components.second) == 0
                     expect(components.nanosecond) == 0
-                    expect(components.calendar) == NSCalendar.currentCalendar()
-                    expect(components.timeZone) == NSTimeZone.localTimeZone()
+                    expect(components.calendar) == Calendar.currentCalendar()
+                    expect(components.timeZone) == TimeZone.localTimeZone()
                 }
 
             }
 */
-            context("NSDate ports") {
+            context("Date ports") {
 
                 it("should return a zero time interval for 1-Jan-2001 00:00:00.000 UTC") {
-                    let refDate = NSDate(timeIntervalSinceReferenceDate: 0)
+                    let refDate = Date(timeIntervalSinceReferenceDate: 0)
                     let date = DateInRegion(absoluteTime: refDate, region: utc)
 
                     expect(date.timeIntervalSinceReferenceDate) == 0
@@ -109,7 +109,7 @@ class DateInRegionSpec: QuickSpec {
                 it("should report the maximum date") {
                     let testDate = DateInRegion(year: 5, month: 2, day: 3, region: amsterdam)
                     let maxDate = DateInRegion.latestDate(
-                        DateInRegion(year: 1, month: 2, day: 3, region: amsterdam),
+                        in: DateInRegion(year: 1, month: 2, day: 3, region: amsterdam),
                         DateInRegion(year: 2, month: 2, day: 3, region: amsterdam),
                         DateInRegion(year: 3, month: 2, day: 3, region: amsterdam),
                         testDate,
@@ -120,7 +120,7 @@ class DateInRegionSpec: QuickSpec {
                 it("should report the minimum date") {
                     let testDate = DateInRegion(year: 100, month: 2, day: 3)
                     let minDate = DateInRegion.earliestDate(
-                        DateInRegion(year: 101, month: 2, day: 3),
+                        in: DateInRegion(year: 101, month: 2, day: 3),
                         DateInRegion(year: 102, month: 2, day: 3),
                         DateInRegion(year: 103, month: 2, day: 3),
                         testDate,
@@ -134,7 +134,7 @@ class DateInRegionSpec: QuickSpec {
 
                 it("should return a midnight date with nil YMD initialisation with UTC time zone") {
                     let date = DateInRegion(year: 1912, month: 6, day: 23, region: utc)
-                    let calendar = date.calendar
+                    var calendar = date.calendar
                     calendar.timeZone = utc.timeZone
 
                     expect(date.year) == 1912
@@ -195,8 +195,8 @@ class DateInRegionSpec: QuickSpec {
                 }
 
                 it("should return a date of 0001-01-01 00:00:00.000 UTC for component initialisation") {
-                    let components = NSDateComponents()
-                    let nsDate = NSCalendar.currentCalendar().dateFromComponents(components)!
+                    let components = DateComponents()
+                    let nsDate = Calendar.current.date(from: components)!
                     let date = DateInRegion(components)
                     let expectedDate = DateInRegion(absoluteTime: nsDate)
 
@@ -309,7 +309,7 @@ class DateInRegionSpec: QuickSpec {
             context("conversions") {
 
                 let date1 = DateInRegion(year: 1999, month: 12, day: 31, region: amsterdam)
-                let date2 = date1.inRegion(jerusalem)
+                let date2 = date1.inRegion(region: jerusalem)
 
                 it("should convert to another calendar") {
                     expect(date2.day) == 22
@@ -326,7 +326,7 @@ class DateInRegionSpec: QuickSpec {
                 }
 
                 it("should convert to another locale") {
-                    expect(date2.toString(dateStyle: .MediumStyle)) == "22 Tevet 5760"
+                    expect(date2.toString(dateStyle: .medium)) == "22 Tevet 5760"
                 }
 
                 it("should convert to another region") {
@@ -352,13 +352,13 @@ class DateInRegionSpec: QuickSpec {
 
                 it("should fail init with nil return") {
                     let string = "2015-01-05T22:10:abc"
-                    let date = DateInRegion(fromString: string, format: DateFormat.ISO8601Format(.Full), region: utc)
+                    let date = DateInRegion(fromString: string, format: DateFormat.iso8601Format(.full), region: utc)
                     expect(date).to(beNil())
                 }
 
                 it("should init from a ISO 8601 string without Z (YYYY-MM-DDThh:mm:ss)") {
                     let string = "2015-01-05T22:10:55+0000"
-                    let date = DateInRegion(fromString: string, format: DateFormat.ISO8601Format(.Full), region: utc)
+                    let date = DateInRegion(fromString: string, format: DateFormat.iso8601Format(.full), region: utc)
                     expect(date).toNot(beNil())
                     expect(date!.year) == 2015
                     expect(date!.month) == 1
@@ -366,12 +366,12 @@ class DateInRegionSpec: QuickSpec {
                     expect(date!.hour) == 22
                     expect(date!.minute) == 10
                     expect(date!.second) == 55
-                    expect(date!.timeZone.secondsFromGMT) == 0
+                    expect(date!.timeZone.secondsFromGMT()) == 0
                 }
 
                 it("should init from a ISO 8601 string with Z") {
                     let string = "2015-01-05T22:10:55Z"
-                    let date = DateInRegion(fromString: string, format: DateFormat.ISO8601Format(.Full), region: utc)
+                    let date = DateInRegion(fromString: string, format: DateFormat.iso8601Format(.full), region: utc)
                     expect(date).toNot(beNil())
                     expect(date!.year) == 2015
                     expect(date!.month) == 1
@@ -379,12 +379,12 @@ class DateInRegionSpec: QuickSpec {
                     expect(date!.hour) == 22
                     expect(date!.minute) == 10
                     expect(date!.second) == 55
-                    expect(date!.timeZone.secondsFromGMT) == 0
+                    expect(date!.timeZone.secondsFromGMT()) == 0
                 }
 
                 it("should init from ISO 8601 date string") {
                     let string = "2015-01-05"
-                    let date = DateInRegion(fromString: string, format: DateFormat.ISO8601Format(.Date), region: utc)
+                    let date = DateInRegion(fromString: string, format: DateFormat.iso8601Format(.date), region: utc)
                     expect(date).toNot(beNil())
                     expect(date!.year) == 2015
                     expect(date!.month) == 1
@@ -392,12 +392,12 @@ class DateInRegionSpec: QuickSpec {
                     expect(date!.hour) == 0
                     expect(date!.minute) == 0
                     expect(date!.second) == 0
-                    expect(date!.timeZone.secondsFromGMT) == 0
+                    expect(date!.timeZone.secondsFromGMT()) == 0
                 }
 
                 it("should init from Alt RSS date string") {
                     let string = "09 Sep 2011 15:26:08 -0400"
-                    let date = DateInRegion(fromString: string, format: DateFormat.AltRSS, region: utc)
+                    let date = DateInRegion(fromString: string, format: DateFormat.altRSS, region: utc)
                     expect(date).toNot(beNil())
                     expect(date!.year) == 2011
                     expect(date!.month) == 9
@@ -405,12 +405,12 @@ class DateInRegionSpec: QuickSpec {
                     expect(date!.hour) == 19
                     expect(date!.minute) == 26
                     expect(date!.second) == 08
-                    expect(date!.timeZone.secondsFromGMT) == 0
+                    expect(date!.timeZone.secondsFromGMT()) == 0
                 }
 
                 it("should init from Alt RSS date string with Z") {
                     let string = "09 Sep 2011 15:26:08 Z"
-                    let date = DateInRegion(fromString: string, format: DateFormat.AltRSS, region: utc)
+                    let date = DateInRegion(fromString: string, format: DateFormat.altRSS, region: utc)
                     expect(date).toNot(beNil())
                     expect(date!.year) == 2011
                     expect(date!.month) == 9
@@ -418,12 +418,12 @@ class DateInRegionSpec: QuickSpec {
                     expect(date!.hour) == 15
                     expect(date!.minute) == 26
                     expect(date!.second) == 08
-                    expect(date!.timeZone.secondsFromGMT) == 0
+                    expect(date!.timeZone.secondsFromGMT()) == 0
                 }
 
                 it("should init from RSS date string with time zone") {
                     let string = "Fri, 09 Sep 2011 15:26:08 +0200"
-                    let date = DateInRegion(fromString: string, format: DateFormat.RSS, region: utc)
+                    let date = DateInRegion(fromString: string, format: DateFormat.rss, region: utc)
                     expect(date).toNot(beNil())
                     expect(date!.year) == 2011
                     expect(date!.month) == 9
@@ -431,12 +431,12 @@ class DateInRegionSpec: QuickSpec {
                     expect(date!.hour) == 13
                     expect(date!.minute) == 26
                     expect(date!.second) == 08
-                    expect(date!.timeZone.secondsFromGMT) == 0
+                    expect(date!.timeZone.secondsFromGMT()) == 0
                 }
 
                 it("should init from RSS date string with Z") {
                     let string = "Fri, 09 Sep 2011 15:26:08 Z"
-                    let date = DateInRegion(fromString: string, format: DateFormat.RSS, region: utc)
+                    let date = DateInRegion(fromString: string, format: DateFormat.rss, region: utc)
                     expect(date).toNot(beNil())
                     expect(date!.year) == 2011
                     expect(date!.month) == 9
@@ -444,12 +444,12 @@ class DateInRegionSpec: QuickSpec {
                     expect(date!.hour) == 15
                     expect(date!.minute) == 26
                     expect(date!.second) == 08
-                    expect(date!.timeZone.secondsFromGMT) == 0
+                    expect(date!.timeZone.secondsFromGMT()) == 0
                 }
 
                 it("should init from Extended date string") {
                     let string = "Fri 09-Sep-2011 AD 15:26:08.123 +0100"
-                    let date = DateInRegion(fromString: string, format: DateFormat.Extended, region: utc)
+                    let date = DateInRegion(fromString: string, format: DateFormat.extended, region: utc)
                     expect(date).toNot(beNil())
                     expect(date!.year) == 2011
                     expect(date!.month) == 9
@@ -458,12 +458,12 @@ class DateInRegionSpec: QuickSpec {
                     expect(date!.minute) == 26
                     expect(date!.second) == 08
                     expect(date!.nanosecond).to(beCloseTo(123000000, within: 100))
-                    expect(date!.timeZone.secondsFromGMT) == 0
+                    expect(date!.timeZone.secondsFromGMT()) == 0
                 }
 
                 it("should init from custom format date string") {
                     let string = "090911"
-                    let date = DateInRegion(fromString: string, format: DateFormat.Custom("ddMMyy"))
+                    let date = DateInRegion(fromString: string, format: DateFormat.custom("ddMMyy"))
                     expect(date).toNot(beNil())
                     expect(date!.year) == 2011
                     expect(date!.month) == 9
@@ -480,21 +480,21 @@ class DateInRegionSpec: QuickSpec {
                 }
 
                 it("should assign calendar, time zone and locale properly") {
-                    let testDate = date.inRegion(bangkok)
-                    expect(testDate.toString(.LongStyle)) == "1 มกราคม 2543 5 นาฬิกา 59 นาที 59 วินาที GMT+7"
+                    let testDate = date.inRegion(region: bangkok)
+                    expect(testDate.toString(style: .long)) == "1 มกราคม 2543 5 นาฬิกา 59 นาที 59 วินาที GMT+7"
                 }
 
                 it("should return a proper string by default") {
                     let date = DateInRegion(year: 1999, month: 12, day: 31)
 
-                    let formatter = NSDateFormatter()
-                    formatter.dateStyle = .MediumStyle
-                    formatter.timeStyle = .MediumStyle
+                    let formatter = DateFormatter()
+                    formatter.dateStyle = .medium
+                    formatter.timeStyle = .medium
                     formatter.calendar = date.calendar
                     formatter.locale = date.locale
                     formatter.timeZone = date.timeZone
 
-                    expect(date.toString(.MediumStyle)) == formatter.stringFromDate(date.absoluteTime)
+                    expect(date.toString(style: .medium)) == formatter.string(from: date.absoluteTime)
                 }
 
                 // TODO: new relative string conversion test
@@ -601,7 +601,7 @@ class DateInRegionSpec: QuickSpec {
         context("Int extensions") {
 
             it("should return proper integer extension values") {
-                let expectedComponents = NSDateComponents()
+                var expectedComponents = DateComponents()
                 expectedComponents.day = 1
                 expect(1.days) == expectedComponents
             }
@@ -638,9 +638,9 @@ class DateInRegionSpec: QuickSpec {
             it("should differ properly") {
                 let date1 = DateInRegion(year: 2001, month: 2, day: 1)
                 let date2 = DateInRegion(year: 2003, month: 1, day: 10)
-                let components = date1.difference(date2, unitFlags: [.Month, .Year])
+                let components = date1.difference(to: date2, componentFlags: [.month, .year])
 
-                let expectedComponents = NSDateComponents()
+                var expectedComponents = DateComponents()
                 expectedComponents.month = 11
                 expectedComponents.year = 1
 
@@ -657,7 +657,7 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of second") {
-                let testDate = date.startOf(.Second)
+                let testDate = date.startOf(component: .second)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 12
@@ -669,7 +669,7 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of minute") {
-                let testDate = date.startOf(.Minute)
+                let testDate = date.startOf(component: .minute)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 12
@@ -681,7 +681,7 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of hour") {
-                let testDate = date.startOf(.Hour)
+                let testDate = date.startOf(component: .hour)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 12
@@ -693,7 +693,7 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of day") {
-                let testDate = date.startOf(.Day)
+                let testDate = date.startOf(component: .day)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 12
@@ -705,8 +705,8 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of day for midnight") {
-                date = date.startOf(.Day)
-                let testDate = date.startOf(.Day)
+                date = date.startOf(component: .day)
+                let testDate = date.startOf(component: .day)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 12
@@ -718,7 +718,7 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of week in Europe") {
-                let testDate = date.startOf(.WeekOfYear)
+                let testDate = date.startOf(component: .weekOfYear)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 12
@@ -730,7 +730,7 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of year for week in Europe") {
-                let testDate = date.startOf(.YearForWeekOfYear)
+                let testDate = date.startOf(component: .yearForWeekOfYear)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 1
@@ -742,7 +742,7 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of weekday") {
-                let testDate = date.startOf(.Weekday)
+                let testDate = date.startOf(component: .weekday)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 12
@@ -754,8 +754,8 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of week in USA") {
-                let usaDate = date.inRegion(newYork)
-                let testDate = usaDate.startOf(.WeekOfYear)
+                let usaDate = date.inRegion(region: newYork)
+                let testDate = usaDate.startOf(component: .weekOfYear)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 12
@@ -767,7 +767,7 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of month") {
-                let testDate = date.startOf(.Month)
+                let testDate = date.startOf(component: .month)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 12
@@ -779,7 +779,7 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of year") {
-                let testDate = date.startOf(.Year)
+                let testDate = date.startOf(component: .year)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 1
@@ -791,7 +791,7 @@ class DateInRegionSpec: QuickSpec {
             }
 
             it("should return start of era") {
-                let testDate = date.startOf(.Era)
+                let testDate = date.startOf(component: .era)
 
                 expect(testDate.year) == 1
                 expect(testDate.month) == 1
@@ -808,7 +808,7 @@ class DateInRegionSpec: QuickSpec {
 
             it("should return end of day") {
                 let date = DateInRegion(year: 1999, month: 1, day: 1, hour: 14, minute: 15, second: 16, nanosecond: 17)
-                let testDate = date.endOf(.Day)
+                let testDate = date.endOf(component: .day)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 1
@@ -821,7 +821,7 @@ class DateInRegionSpec: QuickSpec {
 
             it("should return end of month") {
                 let date = DateInRegion(year: 1999, month: 1, day: 1, hour: 14, minute: 15, second: 16, nanosecond: 17)
-                let testDate = date.endOf(.Month)
+                let testDate = date.endOf(component: .month)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 1
@@ -833,7 +833,7 @@ class DateInRegionSpec: QuickSpec {
 
             it("should return end of year") {
                 let date = DateInRegion(year: 1999, month: 1, day: 1, hour: 14, minute: 15, second: 16, nanosecond: 17)
-                let testDate = date.endOf(.Year)
+                let testDate = date.endOf(component: .year)
 
                 expect(testDate.year) == 1999
                 expect(testDate.month) == 12
@@ -848,7 +848,7 @@ class DateInRegionSpec: QuickSpec {
         context("Copying") {
             it("should create a copy and not a reference") {
                 let a = DateInRegion()
-                let b = a.inRegion(a.region)
+                let b = a.inRegion(region: a.region)
 
                 expect(a) == b
             }

--- a/Sources/SwiftDateTests/NSCalendarTests.swift
+++ b/Sources/SwiftDateTests/NSCalendarTests.swift
@@ -1,5 +1,5 @@
 //
-//  SwiftDateCalendarTests.swift
+//  NSCalendarTests.swift
 //  SwiftDate
 //
 //  Created by Jeroen Houtzager on 22/02/16.
@@ -15,96 +15,96 @@ class NSCalendarSpec: QuickSpec {
 
     override func spec() {
 
-        describe("NSCalendar") {
+        describe("Calendar") {
 
-            let gregorian = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)!
-            let date = NSDate(year: 2016, month: 2, day: 3)
+            let gregorian = Calendar(identifier: Calendar.Identifier.gregorian)
+            let date = Date(year: 2016, month: 2, day: 3)
 
             context("rangeOfUnit") {
 
                 it("day") {
-                    let interval = gregorian.rangeOfUnit(.Day, forDate: date)
+                    let interval = gregorian.range(of: .day, for: date)
                     expect(interval).toNot(beNil())
-                    expect(interval!.start) == NSDate(year: 2016, month: 2, day: 3)
-                    expect(interval!.end) == NSDate(year: 2016, month: 2, day: 4)
+                    expect(interval!.start) == Date(year: 2016, month: 2, day: 3)
+                    expect(interval!.end) == Date(year: 2016, month: 2, day: 4)
                 }
 
                 it("month") {
-                    let interval = gregorian.rangeOfUnit(.Month, forDate: date)
+                    let interval = gregorian.range(of: .month, for: date)
                     expect(interval).toNot(beNil())
-                    expect(interval!.start) == NSDate(year: 2016, month: 2, day: 1)
-                    expect(interval!.end) == NSDate(year: 2016, month: 3, day: 1)
+                    expect(interval!.start) == Date(year: 2016, month: 2, day: 1)
+                    expect(interval!.end) == Date(year: 2016, month: 3, day: 1)
                 }
             }
 
             context("fromType") {
 
                 it("should return a Gregorian calendar") {
-                    expect(CalendarName.Gregorian.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)
+                    expect(CalendarName.gregorian.calendar) == Calendar(identifier: Calendar.Identifier.gregorian)
                 }
 
                 it("should return a Coptic calendar") {
-                    expect(CalendarName.Coptic.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierCoptic)
+                    expect(CalendarName.coptic.calendar) == Calendar(identifier: Calendar.Identifier.coptic)
                 }
 
                 it("should return a Islamic calendar") {
-                    expect(CalendarName.Islamic.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierIslamic)
+                    expect(CalendarName.islamic.calendar) == Calendar(identifier: Calendar.Identifier.islamic)
                 }
 
                 it("should return a Islamic calendar") {
-                    expect(CalendarName.IslamicCivil.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierIslamicCivil)
+                    expect(CalendarName.islamicCivil.calendar) == Calendar(identifier: Calendar.Identifier.islamicCivil)
                 }
 
                 it("should return a Islamic calendar") {
-                    expect(CalendarName.IslamicTabular.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierIslamicTabular)
+                    expect(CalendarName.islamicTabular.calendar) == Calendar(identifier: Calendar.Identifier.islamicTabular)
                 }
 
                 it("should return a Islamic calendar") {
-                    expect(CalendarName.IslamicUmmAlQura.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierIslamicUmmAlQura)
+                    expect(CalendarName.islamicUmmAlQura.calendar) == Calendar(identifier: Calendar.Identifier.islamicUmmAlQura)
                 }
 
                 it("should return a Buddhist calendar") {
-                    expect(CalendarName.Buddhist.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierBuddhist)
+                    expect(CalendarName.buddhist.calendar) == Calendar(identifier: Calendar.Identifier.buddhist)
                 }
 
                 it("should return a Ethiopian calendar") {
-                    expect(CalendarName.EthiopicAmeteAlem.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierEthiopicAmeteAlem)
+                    expect(CalendarName.ethiopicAmeteAlem.calendar) == Calendar(identifier: Calendar.Identifier.ethiopicAmeteAlem)
                 }
 
                 it("should return a Ethiopian calendar") {
-                    expect(CalendarName.EthiopicAmeteMihret.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierEthiopicAmeteMihret)
+                    expect(CalendarName.ethiopicAmeteMihret.calendar) == Calendar(identifier: Calendar.Identifier.ethiopicAmeteMihret)
                 }
 
                 it("should return a Hebrew calendar") {
-                    expect(CalendarName.Hebrew.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierHebrew)
+                    expect(CalendarName.hebrew.calendar) == Calendar(identifier: Calendar.Identifier.hebrew)
                 }
 
                 it("should return a ISO8601 calendar") {
-                    expect(CalendarName.ISO8601.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierISO8601)
+                    expect(CalendarName.iso8601.calendar) == Calendar(identifier: Calendar.Identifier.iso8601)
                 }
 
                 it("should return an Indian calendar") {
-                    expect(CalendarName.Indian.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierIndian)
+                    expect(CalendarName.indian.calendar) == Calendar(identifier: Calendar.Identifier.indian)
                 }
 
                 it("should return a Japanese calendar") {
-                    expect(CalendarName.Japanese.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierJapanese)
+                    expect(CalendarName.japanese.calendar) == Calendar(identifier: Calendar.Identifier.japanese)
                 }
 
                 it("should return a Persian calendar") {
-                    expect(CalendarName.Persian.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierPersian)
+                    expect(CalendarName.persian.calendar) == Calendar(identifier: Calendar.Identifier.persian)
                 }
 
                 it("should return a current calendar") {
-                    expect(CalendarName.Current.calendar) == NSCalendar.currentCalendar()
+                    expect(CalendarName.current.calendar) == Calendar.current
                 }
 
                 it("should return an autoupdating current calendar") {
-                    expect(CalendarName.AutoUpdatingCurrent.calendar) == NSCalendar.autoupdatingCurrentCalendar()
+                    expect(CalendarName.autoUpdatingCurrent.calendar) == Calendar.autoupdatingCurrent
                 }
 
                 it("should return a chinese calendar") {
-                    expect(CalendarName.RepublicOfChina.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierRepublicOfChina)
+                    expect(CalendarName.republicOfChina.calendar) == Calendar(identifier: Calendar.Identifier.republicOfChina)
                 }
             }
         }

--- a/Sources/SwiftDateTests/NSDateComponentPortTests.swift
+++ b/Sources/SwiftDateTests/NSDateComponentPortTests.swift
@@ -16,11 +16,11 @@ class NSDateComponentPortSpec: QuickSpec {
 
     override func spec() {
 
-        describe("NSDateComponentPort") {
+        describe("DateComponentPort") {
 
             context("valueForComponentYMD") {
 
-                let date = NSDate(era: 1, year: 2002, month: 3, day: 4, hour: 5, minute: 6, second: 7, nanosecond: 87654321)
+                let date = Date(era: 1, year: 2002, month: 3, day: 4, hour: 5, minute: 6, second: 7, nanosecond: 87654321)
 
                 it("should report a valid date") {
                     expect(date).toNot(beNil())
@@ -62,7 +62,7 @@ class NSDateComponentPortSpec: QuickSpec {
 
             context("valueForComponentYWD") {
 
-                let date = NSDate(era: 1, yearForWeekOfYear: 2, weekOfYear: 3, weekday: 4)
+                let date = Date(era: 1, yearForWeekOfYear: 2, weekOfYear: 3, weekday: 4)
 
                 it("should report a valid date") {
                     expect(date).toNot(beNil())
@@ -104,7 +104,7 @@ class NSDateComponentPortSpec: QuickSpec {
             
             context("julianDays") {
                 
-                let date = NSDate(era: 1, year: 2016, month: 5, day: 20, hour: 22, minute: 19, second: 7, nanosecond: 87654321)
+                let date = Date(era: 1, year: 2016, month: 5, day: 20, hour: 22, minute: 19, second: 7, nanosecond: 87654321)
 
                 it("should report a valid julian day") {
                     expect(date.julianDay()).to(beCloseTo(2457529.346609, within: 0.000001))
@@ -119,34 +119,34 @@ class NSDateComponentPortSpec: QuickSpec {
             context("component initialisation") {
 
                 it("should return a midnight date YMD initialisation (summer)") {
-                    let date = NSDate(year: 2002, month: 6, day: 23)
+                    let date = Date(year: 2002, month: 6, day: 23)
 
                     expect(date).toNot(beNil())
-                    let calendar = NSCalendar.currentCalendar()
-                    let components = calendar.components([.Year, .Month, .Day], fromDate: date)
+                    let calendar = Calendar.current
+                    let components = calendar.dateComponents([.year, .month, .day], from: date)
                     expect(components.year) == 2002
                     expect(components.month) == 6
                     expect(components.day) == 23
-                    expect(components.hour) == NSDateComponentUndefined
-                    expect(components.minute) == NSDateComponentUndefined
+                    expect(components.hour) == nil
+                    expect(components.minute) == nil
                 }
 
                 it("should return a midnight date YMD initialisation (winter)") {
-                    let date = NSDate(year: 2002, month: 12, day: 23)
+                    let date = Date(year: 2002, month: 12, day: 23)
 
                     expect(date).toNot(beNil())
-                    let calendar = NSCalendar.currentCalendar()
-                    let components = calendar.components([.Year, .Month, .Day], fromDate: date)
+                    let calendar = Calendar.current
+                    let components = calendar.dateComponents([.year, .month, .day], from: date)
                     expect(components.year) == 2002
                     expect(components.month) == 12
                     expect(components.day) == 23
                 }
 
                 it("should return a midnight date with nil YMD initialisation") {
-                    let date = NSDate(year: 1912, month: 6, day: 23)
+                    let date = Date(year: 1912, month: 6, day: 23)
 
-                    let calendar = NSCalendar.currentCalendar()
-                    let components = calendar.components([.Year, .Month, .Day], fromDate: date)
+                    let calendar = Calendar.current
+                    var components = calendar.dateComponents([.year, .month, .day], from: date)
                     expect(components.year) == 1912
                     expect(components.month) == 6
                     expect(components.day) == 23
@@ -154,26 +154,26 @@ class NSDateComponentPortSpec: QuickSpec {
 
 
                 it("should return a midnight date with nil YWD initialisation") {
-                    let newYork = Region(calendarName: .Gregorian, timeZoneName: .AmericaNewYork, localeName: .EnglishUnitedStates)
-                    let date = NSDate(yearForWeekOfYear: 1492, weekOfYear: 15, weekday: 4, region: newYork)
-                    let components = NSDateComponents()
+                    let newYork = Region(calendarName: .gregorian, timeZoneName: .americaNewYork, localeName: .englishUnitedStates)
+                    let date = Date(yearForWeekOfYear: 1492, weekOfYear: 15, weekday: 4, region: newYork)
+                    var components = DateComponents()
                     components.yearForWeekOfYear = 1492
                     components.weekOfYear = 15
                     components.weekday = 4
                     components.calendar = newYork.calendar
                     components.timeZone = newYork.timeZone
-                    let expectedDate = newYork.calendar.dateFromComponents(components)!
+                    let expectedDate = newYork.calendar.date(from: components)!
 
                     expect(date) == expectedDate
                 }
 
 
                 it("should return a date of 0001-01-01 00:00:00.000 in the default region for component initialisation") {
-                    let components = NSDateComponents()
-                    let date = NSDate(components: components)
+                    let components = DateComponents()
+                    let date = Date(components: components)
 
-                    let calendar = NSCalendar.currentCalendar()
-                    let testComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: date)
+                    let calendar = Calendar.current
+                    let testComponents = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
                     expect(testComponents.year) == 1
                     expect(testComponents.month) == 1
                     expect(testComponents.day) == 1
@@ -185,8 +185,8 @@ class NSDateComponentPortSpec: QuickSpec {
 
             context("special components") {
 
-                let date = NSDate(year: 2015, month: 12, day: 16)
-                let newYork = Region(calendarName: .Gregorian, timeZoneName: .AmericaNewYork, localeName: .EnglishUnitedStates)
+                let date = Date(year: 2015, month: 12, day: 16)
+                let newYork = Region(calendarName: .gregorian, timeZoneName: .americaNewYork, localeName: .englishUnitedStates)
 
                 it("should report the proper first day of the week") {
                     let firstDay = date.firstDayOfWeek(inRegion: newYork)
@@ -202,40 +202,40 @@ class NSDateComponentPortSpec: QuickSpec {
 
             context("component calculations") {
 
-                let undefined = NSDateComponents()
+                let undefined = DateComponents()
                 let zero = 0.days
                 let day1 = 1.days
 
                 it("should return undefined with undefined components") {
-                    expect(sumDateComponents(undefined, rhs: undefined)) == undefined
+                    expect(sumDateComponents(lhs: undefined, rhs: undefined)) == undefined
                 }
 
                 it("should return 1 day with 1 day summed with undefined components") {
-                    expect(sumDateComponents(day1, rhs: undefined)) == day1
+                    expect(sumDateComponents(lhs: day1, rhs: undefined)) == day1
                 }
 
                 it("should return 1 day with undefined components summed with 1 day") {
-                    expect(sumDateComponents(undefined, rhs: day1)) == day1
+                    expect(sumDateComponents(lhs: undefined, rhs: day1)) == day1
                 }
 
                 it("should return zero with zero components") {
-                    expect(sumDateComponents(zero, rhs: zero)) == zero
+                    expect(sumDateComponents(lhs: zero, rhs: zero)) == zero
                 }
 
                 it("should return 1 day with 1 day summed with zero components") {
-                    expect(sumDateComponents(day1, rhs: zero)) == day1
+                    expect(sumDateComponents(lhs: day1, rhs: zero)) == day1
                 }
 
                 it("should return 1 day with zero components summed with 1 day") {
-                    expect(sumDateComponents(zero, rhs: day1)) == day1
+                    expect(sumDateComponents(lhs: zero, rhs: day1)) == day1
                 }
 
                 it("should return 2 days with 1 day components summed") {
-                    expect(sumDateComponents(day1, rhs: day1)) == 2.days
+                    expect(sumDateComponents(lhs: day1, rhs: day1)) == 2.days
                 }
 
                 it("should return zero with 1 day components subtracted") {
-                    expect(sumDateComponents(day1, rhs: day1, sum: false)) == zero
+                    expect(sumDateComponents(lhs: day1, rhs: day1, sum: false)) == zero
                 }
 
                 it("should sum properly with +") {

--- a/Sources/SwiftDateTests/NSDateComponentsTests.swift
+++ b/Sources/SwiftDateTests/NSDateComponentsTests.swift
@@ -15,17 +15,17 @@ class NSDateComponentsSpec: QuickSpec {
 
     override func spec() {
 
-        describe("NSDateComponents") {
+        describe("DateComponents") {
 
-            var components: NSDateComponents!
-            var date: NSDate!
+            var components: DateComponents!
+            var date: Date!
             beforeEach {
-                components = NSDateComponents()
+                components = DateComponents()
                 components.year = 1
                 components.month = 2
                 components.day = 3
                 components.second = 4
-                date = NSDate(year: 2006, month: 7, day: 19, hour: 13)
+                date = Date(year: 2006, month: 7, day: 19, hour: 13)
             }
 
             context("fromDate") {

--- a/Sources/SwiftDateTests/NSDateEquationsTests.swift
+++ b/Sources/SwiftDateTests/NSDateEquationsTests.swift
@@ -14,25 +14,25 @@ class NSDateEquationsTests: QuickSpec {
 
     override func spec() {
 
-        describe("NSDateEquations") {
+        describe("DateEquations") {
 
             it("should return true for equating a different object with the same properties") {
-                let date1 = NSDate(year: 1999, month: 12, day: 31)
+                let date1 = Date(year: 1999, month: 12, day: 31)
                 let date2 = date1
 
                 expect(date1 == date2) == true
             }
 
             it("should return true for equating the same object") {
-                let date1 = NSDate(year: 1999, month: 12, day: 31)
+                let date1 = Date(year: 1999, month: 12, day: 31)
                 let date2 = date1
 
                 expect(date1 == date2) == true
             }
 
             it("should return false for equating objects with different dates") {
-                let date1 = NSDate(year: 1999, month: 12, day: 31)
-                let date2 = NSDate(year: 1999, month: 12, day: 30)
+                let date1 = Date(year: 1999, month: 12, day: 31)
+                let date2 = Date(year: 1999, month: 12, day: 30)
 
                 expect(date1 == date2) == false
             }

--- a/Sources/SwiftDateTests/NSDateIntervalTests.swift
+++ b/Sources/SwiftDateTests/NSDateIntervalTests.swift
@@ -12,29 +12,29 @@ import Quick
 import Nimble
 import SwiftDate
 
-class NSDateIntervalSpec: QuickSpec {
+class DateIntervalSpec: QuickSpec {
 
     override func spec() {
 
-        describe("NSDateInterval") {
+        describe("DateInterval") {
 
             context("initialisation") {
 
                 it("start & end") {
-                    let startDate = NSDate(year: 2012, month: 3, day: 4)
-                    let endDate = NSDate(year: 2012, month: 3, day: 5)
+                    let startDate = Date(year: 2012, month: 3, day: 4)
+                    let endDate = Date(year: 2012, month: 3, day: 5)
 
-                    let dateInterval = NSDateInterval(start: startDate, end: endDate)
+                    let dateInterval = SwiftDate.DateInterval(start: startDate, end: endDate)
                     expect(dateInterval).toNot(beNil())
                     expect(dateInterval.start) == startDate
                     expect(dateInterval.end) == endDate
                 }
 
                 it("interval") {
-                    let startDate = NSDate(year: 2012, month: 3, day: 4)
-                    let interval = NSTimeInterval(24 * 60 * 60)
+                    let startDate = Date(year: 2012, month: 3, day: 4)
+                    let interval = TimeInterval(24 * 60 * 60)
 
-                    let dateInterval = NSDateInterval(start: startDate, interval: interval)
+                    let dateInterval = DateInterval(start: startDate, interval: interval)
                     expect(dateInterval).toNot(beNil())
                     expect(dateInterval.start) == startDate
                     expect(dateInterval.interval) == interval

--- a/Sources/SwiftDateTests/NSDateTests.swift
+++ b/Sources/SwiftDateTests/NSDateTests.swift
@@ -16,57 +16,57 @@ class NSDateSpec: QuickSpec {
 
     override func spec() {
 
-        describe("NSDate extension") {
+        describe("Date extension") {
 
-            var date: NSDate!
+            var date: Date!
             var newYork: Region!
             var amsterdam: Region!
             var rome: Region!
             beforeEach {
-                date = NSDate(year: 2001, month: 2, day: 3, region: amsterdam)
-                newYork = Region(calendarName: .Gregorian, timeZoneName: .AmericaNewYork, localeName: .EnglishUnitedStates)
-                amsterdam = Region(calendarName: .Gregorian, timeZoneName: .EuropeAmsterdam, localeName: .DutchNetherlands)
-                rome = Region(calendarName: .Gregorian, timeZoneName: .EuropeRome, localeName: .ItalianItaly)
+                date = Date(year: 2001, month: 2, day: 3, region: amsterdam)
+                newYork = Region(calendarName: .gregorian, timeZoneName: .americaNewYork, localeName: .englishUnitedStates)
+                amsterdam = Region(calendarName: .gregorian, timeZoneName: .europeAmsterdam, localeName: .dutchNetherlands)
+                rome = Region(calendarName: .gregorian, timeZoneName: .europeRome, localeName: .italianItaly)
             }
 
             context("initialisation") {
 
-                let calendar = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)!
-                let timeZone = NSTimeZone(abbreviation: "CET")
+                let calendar = Calendar(identifier: Calendar.Identifier.gregorian)
+                let timeZone = TimeZone(abbreviation: "CET")
 
                 it("should return the specified YMD date in the default region") {
-                    let date = NSDate(year: 2012, month: 3, day: 4)
+                    let date = Date(year: 2012, month: 3, day: 4)
 
-                    let calendar = NSCalendar.currentCalendar()
-                    let components = NSDateComponents()
+                    let calendar = Calendar.current
+                    var components = DateComponents()
                     components.year = 2012
                     components.month = 3
                     components.day = 4
                     components.calendar = calendar
-                    components.timeZone = NSTimeZone.defaultTimeZone()
-                    let expectedDate = calendar.dateFromComponents(components)
+                    components.timeZone = NSTimeZone.default
+                    let expectedDate = calendar.date(from: components)
 
                     expect(date) == expectedDate
                 }
 
                 it("should return the specified YWD date in the specified region") {
-                    let date = NSDate(yearForWeekOfYear: 2012, weekOfYear: 3, weekday: 4, region: newYork)
+                    let date = Date(yearForWeekOfYear: 2012, weekOfYear: 3, weekday: 4, region: newYork)
 
-                    let components = NSDateComponents()
+                    var components = DateComponents()
                     components.yearForWeekOfYear = 2012
                     components.weekOfYear = 3
                     components.weekday = 4
                     components.calendar = newYork.calendar
                     components.timeZone = newYork.timeZone
-                    let expectedDate = calendar.dateFromComponents(components)
+                    let expectedDate = calendar.date(from: components as DateComponents)
 
                     expect(date) == expectedDate
                 }
 
                 it("should return the specified time in the specified region") {
-                    let date = NSDate(year: 2015, month: 12, day: 25, hour: 13, minute: 14, second: 15, region: rome)
+                    let date = Date(year: 2015, month: 12, day: 25, hour: 13, minute: 14, second: 15, region: rome)
 
-                    let components = NSDateComponents()
+                    var components = DateComponents()
                     components.year = 2015
                     components.month = 12
                     components.day = 25
@@ -75,24 +75,23 @@ class NSDateSpec: QuickSpec {
                     components.second = 15
                     components.calendar = rome.calendar
                     components.timeZone = rome.timeZone
-                    let expectedDate = calendar.dateFromComponents(components)
+                    let expectedDate = calendar.date(from: components as DateComponents)
 
                     expect(date) == expectedDate
                 }
 
                 it("should return the specified time in the specified region with a fromDate") {
-                    let date0 = NSDate(year: 2015, month: 12, day: 25, region: rome)
-                    let date1 = NSDate(fromDate: date0)
+                    let date0 = Date(year: 2015, month: 12, day: 25, region: rome)
+                    let date1 = Date(fromDate: date0)
 
                     expect(date1) == date0
                 }
 
-
                 it("should return the specified time in the specified region with a fromDate") {
-                    let date0 = NSDate(year: 2015, month: 12, day: 25, region: rome)
-                    let date1 = NSDate(fromDate: date0, hour: 13, minute: 14, second: 15, region: amsterdam)
+                    let date0 = Date(year: 2015, month: 12, day: 25, region: rome)
+                    let date1 = Date(fromDate: date0, hour: 13, minute: 14, second: 15, region: amsterdam)
 
-                    let components = calendar.components([.Year, .Month, .Day], fromDate: date1)
+                    var components = calendar.dateComponents([.year, .month, .day], from: date1)
                     components.year = 2015
                     components.month = 12
                     components.day = 25
@@ -101,39 +100,39 @@ class NSDateSpec: QuickSpec {
                     components.second = 15
                     components.calendar = amsterdam.calendar
                     components.timeZone = amsterdam.timeZone
-                    let expectedDate = calendar.dateFromComponents(components)
+                    let expectedDate = calendar.date(from: components)
 
                     expect(date1) == expectedDate
                 }
 
 
                 it("should return the specified time in the specified region with a refDate") {
-                    let date0 = NSDate(year: 2015, month: 12, day: 25, region: rome)
-                    let date = NSDate(refDate: date0)
+                    let date0 = Date(year: 2015, month: 12, day: 25, region: rome)
+                    let date = Date(refDate: date0)
 
                     expect(date) == date0
                 }
 
                 it("should return the specified time with a componect dictionary") {
-                    let date = NSDate(dateComponentDictionary: [.Year: 2015, .Month: 2, .Day: 3])
+                    let date = Date(dateComponentDictionary: [.year: 2015, .month: 2, .day: 3])
 
-                    let expectedDate = NSDate(year: 2015, month: 2, day: 3)
+                    let expectedDate = Date(year: 2015, month: 2, day: 3)
 
                     expect(date) == expectedDate
                 }
 
                 it("should return the specified time in the specified region with components") {
-                    let components = NSDateComponents()
+                    var components = DateComponents()
                     components.year = 2012
                     components.month = 3
                     components.day = 4
                     components.hour = 13
                     components.minute = 14
                     components.second = 15
-                    components.calendar = calendar
-                    components.timeZone = timeZone
-                    let date = NSDate(components: components)
-                    let expectedDate = calendar.dateFromComponents(components)
+                    components.calendar = calendar as Calendar
+                    components.timeZone = timeZone as TimeZone?
+                    let date = Date(components: components)
+                    let expectedDate = calendar.date(from: components as DateComponents)
 
                     expect(date) == expectedDate
                 }
@@ -143,7 +142,7 @@ class NSDateSpec: QuickSpec {
             context("Region") {
 
                 it("Should convert to the right region") {
-                    let date = NSDate()
+                    let date = Date()
 
                     let newYorkDate = date.inRegion(newYork)
 
@@ -155,7 +154,7 @@ class NSDateSpec: QuickSpec {
 
             context("period comparisons") {
 
-                let date = NSDate(year: 2015, month: 12, day: 16, region: newYork)
+                let date = Date(year: 2015, month: 12, day: 16, region: newYork)
 
                 it("should report the proper first day of the week") {
                     let firstDay = date.firstDayOfWeek(inRegion: newYork)!
@@ -171,77 +170,77 @@ class NSDateSpec: QuickSpec {
 
             context("isIn") {
 
-                let date = NSDate(year: 2015, month: 12, day: 14, hour: 13, region: amsterdam)
+                let date = Date(year: 2015, month: 12, day: 14, hour: 13, region: amsterdam)
 
                 it("should report proper results for year granularity unit") {
                     let date1 = date - 1.years
                     let date2 = date - 1.months
                     let date3 = date + 1.years
-                    let unit = NSCalendarUnit.Year
-                    expect(date.isIn(unit, ofDate: date1)) == false
-                    expect(date.isIn(unit, ofDate: date2)) == true
-                    expect(date.isIn(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.year
+                    expect(date.isIn(component: unit, ofDate: date1)) == false
+                    expect(date.isIn(component: unit, ofDate: date2)) == true
+                    expect(date.isIn(component: unit, ofDate: date3)) == false
                 }
 
                 it("should report proper results for month granularity unit") {
                     let date1 = date - 1.months
                     let date2 = date + 1.weeks
                     let date3 = date + 1.months
-                    let unit = NSCalendarUnit.Month
-                    expect(date.isIn(unit, ofDate: date1)) == false
-                    expect(date.isIn(unit, ofDate: date2)) == true
-                    expect(date.isIn(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.month
+                    expect(date.isIn(component: unit, ofDate: date1)) == false
+                    expect(date.isIn(component: unit, ofDate: date2)) == true
+                    expect(date.isIn(component: unit, ofDate: date3)) == false
                 }
 
             }
 
             context("isBefore") {
 
-                let date = NSDate(year: 2015, month: 12, day: 14, hour: 13, region: amsterdam)
+                let date = Date(year: 2015, month: 12, day: 14, hour: 13, region: amsterdam)
 
                 it("should report proper results for minute granularity unit") {
                     let date1 = date - 1.minutes
                     let date2 = date + 1.seconds
                     let date3 = date + 1.minutes
-                    let unit = NSCalendarUnit.Minute
-                    expect(date.isBefore(unit, ofDate: date1)) == false
-                    expect(date.isBefore(unit, ofDate: date2)) == false
-                    expect(date.isBefore(unit, ofDate: date3)) == true
+                    let unit = Calendar.Component.minute
+                    expect(date.isBefore(component: unit, ofDate: date1)) == false
+                    expect(date.isBefore(component: unit, ofDate: date2)) == false
+                    expect(date.isBefore(component: unit, ofDate: date3)) == true
                 }
 
                 it("should report proper results for second granularity unit") {
                     let date1 = date - 1.seconds
                     let date2 = date + 100000.nanoseconds
                     let date3 = date + 1.seconds
-                    let unit = NSCalendarUnit.Second
-                    expect(date.isBefore(unit, ofDate: date1)) == false
-                    expect(date.isBefore(unit, ofDate: date2)) == false
-                    expect(date.isBefore(unit, ofDate: date3)) == true
+                    let unit = Calendar.Component.second
+                    expect(date.isBefore(component: unit, ofDate: date1)) == false
+                    expect(date.isBefore(component: unit, ofDate: date2)) == false
+                    expect(date.isBefore(component: unit, ofDate: date3)) == true
                 }
             }
 
             context("isAfter") {
 
-                let date = NSDate(year: 2015, month: 12, day: 14, hour: 13, region: amsterdam)
+                let date = Date(year: 2015, month: 12, day: 14, hour: 13, region: amsterdam)
 
                 it("should report proper results for week granularity unit") {
                     let date1 = date - 1.weeks
                     let date2 = date + 1.days
                     let date3 = date + 1.weeks
-                    let unit = NSCalendarUnit.WeekOfYear
-                    expect(date.isAfter(unit, ofDate: date1)) == true
-                    expect(date.isAfter(unit, ofDate: date2)) == false
-                    expect(date.isAfter(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.weekOfYear
+                    expect(date.isAfter(component: unit, ofDate: date1)) == true
+                    expect(date.isAfter(component: unit, ofDate: date2)) == false
+                    expect(date.isAfter(component: unit, ofDate: date3)) == false
                 }
 
                 it("should report proper results for hour granularity unit") {
                     let date1 = date - 1.hours
                     let date2 = date + 1.minutes
                     let date3 = date + 1.hours
-                    let unit = NSCalendarUnit.Hour
-                    expect(date.isAfter(unit, ofDate: date1)) == true
-                    expect(date.isAfter(unit, ofDate: date2)) == false
-                    expect(date.isAfter(unit, ofDate: date3)) == false
+                    let unit = Calendar.Component.hour
+                    expect(date.isAfter(component: unit, ofDate: date1)) == true
+                    expect(date.isAfter(component: unit, ofDate: date2)) == false
+                    expect(date.isAfter(component: unit, ofDate: date3)) == false
                 }
 
             }
@@ -253,12 +252,12 @@ class NSDateSpec: QuickSpec {
                 }
 
                 it("should report proper leap months") {
-                    let date = NSDate(year: 2004, month: 2, day: 2)
+                    let date = Date(year: 2004, month: 2, day: 2)
                     expect(date.isInLeapMonth()) == true
                 }
 
                 it("should report proper leap year") {
-                    let date = NSDate(year: 2004, month: 2, day: 2)
+                    let date = Date(year: 2004, month: 2, day: 2)
                     expect(date.isInLeapYear()) == true
                 }
 
@@ -270,7 +269,7 @@ class NSDateSpec: QuickSpec {
 
             context("Comparisons") {
 
-                var date1: NSDate!
+                var date1: Date!
                 beforeEach {
                     date1 = date + 1.days
                 }
@@ -306,37 +305,37 @@ class NSDateSpec: QuickSpec {
                 // Note: these tests are not exhaustive as they are pretty thoroughly tested in DateInRegionComparisonTests
 
                 it("should report true for isInToday with today's date") {
-                    expect(NSDate().isInToday()) == true
+                    expect(Date().isInToday()) == true
                 }
 
                 it("should report false for isInToday with yesterday's date") {
-                    expect((NSDate() - 1.days).isInToday()) == false
+                    expect((Date() - 1.days).isInToday()) == false
                 }
 
                 it("should report true for isInYesterday with yesterday's date") {
-                    expect((NSDate() - 1.days).isInYesterday()) == true
+                    expect((Date() - 1.days).isInYesterday()) == true
                 }
 
                 it("should report false for isInYesterday with today's date") {
-                    expect(NSDate().isInYesterday()) == false
+                    expect(Date().isInYesterday()) == false
                 }
 
                 it("should report true for isInTomorrow with tomorrows date") {
-                    expect((NSDate() + 1.days).isInTomorrow()) == true
+                    expect((Date() + 1.days).isInTomorrow()) == true
                 }
 
                 it("should report false for isInTomorrow with today's date") {
-                    expect(NSDate().isInTomorrow()) == false
+                    expect(Date().isInTomorrow()) == false
                 }
 
                 it("should report true for isSameDaysAsDate with the same day") {
-                    let day = NSDate()
-                    expect(day.isInSameDayAsDate(day)) == true
+                    let day = Date()
+                    expect(day.isInSameDayAsDate(date: day)) == true
                 }
 
                 it("should report today") {
-                    let day = NSDate.today()
-                    let now = NSDate()
+                    let day = Date.today()
+                    let now = Date()
 
                     expect(day.year) == now.year
                     expect(day.month) == now.month
@@ -348,8 +347,8 @@ class NSDateSpec: QuickSpec {
                 }
 
                 it("should report yesterday") {
-                    let day = NSDate.yesterday()
-                    let now = NSDate() - 1.days
+                    let day = Date.yesterday()
+                    let now = Date() - 1.days
 
                     expect(day.year) == now.year
                     expect(day.month) == now.month
@@ -361,8 +360,8 @@ class NSDateSpec: QuickSpec {
                 }
 
                 it("should report tomorrow") {
-                    let day = NSDate.tomorrow()
-                    let now = NSDate() + 1.days
+                    let day = Date.tomorrow()
+                    let now = Date() + 1.days
 
                     expect(day.year) == now.year
                     expect(day.month) == now.month
@@ -374,33 +373,33 @@ class NSDateSpec: QuickSpec {
                 }
 
                 it("should report false for isWeekend with a weekday") {
-                    let day = NSDate(year: 2015, month: 12, day: 15, region: amsterdam)
+                    let day = Date(year: 2015, month: 12, day: 15, region: amsterdam)
                     expect(day.isInWeekend(inRegion: amsterdam)) == false
                 }
 
                 it("should report true for isWeekend with a saturday") {
-                    let day = NSDate(year: 2015, month: 12, day: 5, region: amsterdam)
+                    let day = Date(year: 2015, month: 12, day: 5, region: amsterdam)
                     expect(day.isInWeekend(inRegion: amsterdam)) == true
                 }
 
                 it("should report proper startOf without region") {
-                    let day = NSDate()
-                    expect(day.startOf(.Day)) == NSDate.today()
+                    let day = Date()
+                    expect(day.startOf(component: .day)) == Date.today()
                 }
 
                 it("should report proper endOf without region") {
-                    let day = NSDate()
-                    expect(day.endOf(.Day).timeIntervalSinceReferenceDate).to(beCloseTo(NSDate.tomorrow().timeIntervalSinceReferenceDate, within: 1))
+                    let day = Date()
+                    expect(day.endOf(component: .day).timeIntervalSinceReferenceDate).to(beCloseTo(Date.tomorrow().timeIntervalSinceReferenceDate, within: 1))
                 }
 
                 it("should report proper startOf") {
-                    let day = NSDate(year: 2015, month: 12, day: 5, region: amsterdam)
-                    expect(day.startOf(.Month, inRegion: amsterdam)) == NSDate(year: 2015, month: 12, day: 1, region: amsterdam)
+                    let day = Date(year: 2015, month: 12, day: 5, region: amsterdam)
+                    expect(day.startOf(component: .month, in: amsterdam)) == Date(year: 2015, month: 12, day: 1, region: amsterdam)
                 }
 
                 it("should report proper endOf") {
-                    let day = NSDate(year: 2015, month: 12, day: 5, region: amsterdam)
-                    expect(day.endOf(.Month, inRegion: amsterdam)) == NSDate(year: 2016, month: 1, day: 1, region: amsterdam) - 1000000.nanoseconds
+                    let day = Date(year: 2015, month: 12, day: 5, region: amsterdam)
+                    expect(day.endOf(component: .month, in: amsterdam)) == Date(year: 2016, month: 1, day: 1, region: amsterdam) - 1000000.nanoseconds
                 }
 
                 it("should report true for isInPast with a date in the past") {
@@ -423,14 +422,14 @@ class NSDateSpec: QuickSpec {
 
             context("Calculations") {
 
-                let date = NSDate(year: 2001, month: 2, day: 3)
+                let date = Date(year: 2001, month: 2, day: 3)
 
                 it("should add zero") {
                     expect(date.add()) == date
                 }
 
                 it("should add one day") {
-                    expect(date.add(1.days)) == NSDate(year: 2001, month: 2, day: 4)
+                    expect(date.add(components: 1.days)) == Date(year: 2001, month: 2, day: 4)
                 }
 
                 it("should get components") {
@@ -442,15 +441,15 @@ class NSDateSpec: QuickSpec {
                 }
 
                 it("should calculate difference with the same date and no flags") {
-                    let date2 = NSDate(fromDate: date)
-                    let difference = date.difference(date2, unitFlags: [])
+                    let date2 = Date(fromDate: date)
+                    let difference = date.difference(to: date2, componentFlags: [])
 
-                    expect(difference) == NSDateComponents()
+                    expect(difference) == DateComponents()
                 }
 
                 it("should calculate difference with the same date and flags") {
-                    let date2 = NSDate(fromDate: date)
-                    let difference = date.difference(date2, unitFlags: [.Day, .Month, .Year])
+                    let date2 = Date(fromDate: date)
+                    let difference = date.difference(to: date2, componentFlags: [.day, .month, .year])
 
                     expect(difference) == 0.days + 0.months + 0.years
                 }
@@ -464,51 +463,51 @@ class NSDateSpec: QuickSpec {
                 }
 
                 it("should return toString with custom format") {
-                    expect(date.toString(.Custom("dd-MMM-yy"), inRegion: amsterdam)) == "03-feb.-01"
+                    expect(date.toString(format: .custom("dd-MMM-yy"), in: amsterdam)) == "03-feb.-01"
                 }
 
                 it("should return toString with ISO8601 year format") {
-                    expect(date.toString(.ISO8601Format(.Year), inRegion: amsterdam)) == "2001"
+                    expect(date.toString(format: .iso8601Format(.year), in: amsterdam)) == "2001"
                 }
 
                 it("should return toString with ISO8601 year month format") {
-                    expect(date.toString(.ISO8601Format(.YearMonth), inRegion: amsterdam)) == "2001-02"
+                    expect(date.toString(format: .iso8601Format(.yearMonth), in: amsterdam)) == "2001-02"
                 }
 
                 it("should return toString with ISO8601 date format") {
-                    expect(date.toString(.ISO8601Format(.Date), inRegion: amsterdam)) == "2001-02-03"
+                    expect(date.toString(format: .iso8601Format(.date), in: amsterdam)) == "2001-02-03"
                 }
 				
 				it("should return proper ISO 8601 (hour minute) string") {
-					expect(utcDate.toString(DateFormat.ISO8601Format(.HourMinute))) == "22:10"
+					expect(date.toString(format: DateFormat.iso8601Format(.hourMinute))) == "22:10"
 				}
 				
 				it("should return proper ISO 8601 (time) string") {
-					expect(utcDate.toString(DateFormat.ISO8601Format(.Time))) == "22:10:00"
+					expect(date.toString(format: DateFormat.iso8601Format(.time))) == "22:10:00"
 				}
 
                 it("should return toString with ISO8601 date time format") {
-                    expect(date.toString(.ISO8601Format(.DateTime), inRegion: amsterdam)) == "2001-02-03T00:00+01:00"
+                    expect(date.toString(format: .iso8601Format(.dateTime), in: amsterdam)) == "2001-02-03T00:00+01:00"
                 }
 
                 it("should return toString with full ISO8601 format") {
-                    expect(date.toString(.ISO8601Format(.Full), inRegion: amsterdam)) == "2001-02-03T00:00:00+01:00"
+                    expect(date.toString(format: .iso8601Format(.full), in: amsterdam)) == "2001-02-03T00:00:00+01:00"
                 }
 
                 it("should return toString with extended ISO8601 format") {
-                    expect(date.toString(.ISO8601Format(.Extended), inRegion: amsterdam)) == "2001-02-03T00:00:00.000+01:00"
+                    expect(date.toString(format: .iso8601Format(.extended), in: amsterdam)) == "2001-02-03T00:00:00.000+01:00"
                 }
 
                 it("should return toString with RSS format") {
-                    expect(date.toString(.RSS, inRegion: amsterdam)) == "za, 3 feb. 2001 00:00:00 +0100"
+                    expect(date.toString(format: .rss, in: amsterdam)) == "za, 3 feb. 2001 00:00:00 +0100"
                 }
 
-                it("should return toString with AltRSS format") {
-                    expect(date.toString(.AltRSS, inRegion: amsterdam)) == "3 feb. 2001 00:00:00 +0100"
+                it("should return toString with altRSS format") {
+                    expect(date.toString(format: .altRSS, in: amsterdam)) == "3 feb. 2001 00:00:00 +0100"
                 }
 
                 it("should return toString with extended format") {
-                    expect(date.toString(.Extended, inRegion: amsterdam)) == "za 03-feb.-2001 n.Chr. 00:00:00.000 +0100"
+                    expect(date.toString(format: .extended, in: amsterdam)) == "za 03-feb.-2001 n.Chr. 00:00:00.000 +0100"
                 }
 
             }
@@ -538,7 +537,7 @@ class NSDateSpec: QuickSpec {
 
             context("region") {
 
-                let date = NSDate(year: 2001, month: 2, day: 3)
+                let date = Date(year: 2001, month: 2, day: 3)
 
                 it("should get default region") {
 

--- a/Sources/SwiftDateTests/NSTimeIntervalTests.swift
+++ b/Sources/SwiftDateTests/NSTimeIntervalTests.swift
@@ -19,8 +19,8 @@ class NSTimeIntervalSpec: QuickSpec {
 
             context("fromNow") {
                 it("should return the proper date") {
-                    let now = NSDate()
-                    let interval = NSTimeInterval(3600)
+                    let now = Date()
+                    let interval = TimeInterval(3600)
                     expect(interval.fromNow!) >= now + 1.hours
                     expect(interval.fromNow!) <= now + 1.hours + 1.seconds
                 }
@@ -28,8 +28,8 @@ class NSTimeIntervalSpec: QuickSpec {
 
             context("ago") {
                 it("should return the proper date") {
-                    let now = NSDate()
-                    let interval = NSTimeInterval(3600)
+                    let now = Date()
+                    let interval = TimeInterval(3600)
                     expect(interval.ago!) >= now - 1.hours
                     expect(interval.ago!) <= now - 1.hours + 1.seconds
                 }
@@ -37,8 +37,8 @@ class NSTimeIntervalSpec: QuickSpec {
 
             context("toString") {
                 it("should return the proper string") {
-                    let rome = Region(timeZoneName: .EuropeRome)
-                    let date = NSDate(year: 2011, month: 10, day: 9, region: rome)
+                    let rome = Region(timeZoneName: .europeRome)
+                    let date = Date(year: 2011, month: 10, day: 9, region: rome)
                     let interval = date.timeIntervalSinceReferenceDate
                     expect(interval.toString()) == "10y 9m 5d 22h"
                 }

--- a/Sources/SwiftDateTests/NSTimeZoneTests.swift
+++ b/Sources/SwiftDateTests/NSTimeZoneTests.swift
@@ -15,24 +15,24 @@ class NSTimeZoneSpec: QuickSpec {
 
     override func spec() {
 
-        describe("NSTimeZone") {
+        describe("TimeZone") {
 
             context("fromName") {
 
                 it("should return local time zone") {
-                    expect(TimeZoneName.Local.timeZone) == NSTimeZone.localTimeZone()
+                    expect(TimeZoneName.local.timeZone) == NSTimeZone.local
                 }
 
                 it("should return default TimeZone") {
-                    expect(TimeZoneName.Default.timeZone) == NSTimeZone.defaultTimeZone()
+                    expect(TimeZoneName.default.timeZone) == NSTimeZone.default
                 }
 
                 it("should return system TimeZone") {
-                    expect(TimeZoneName.System.timeZone) == NSTimeZone.systemTimeZone()
+                    expect(TimeZoneName.system.timeZone) == NSTimeZone.system
                 }
 
                 it("should return CET TimeZone") {
-                    expect(TimeZoneName.EuropeParis.timeZone) == NSTimeZone(abbreviation: "CET")
+                    expect(TimeZoneName.europeParis.timeZone) == TimeZone(abbreviation: "CET")
                 }
             }
         }

--- a/Sources/SwiftDateTests/RegionStringTests.swift
+++ b/Sources/SwiftDateTests/RegionStringTests.swift
@@ -14,104 +14,104 @@ class DateRegionStringSpec: QuickSpec {
 
     override func spec() {
 
-        describe("NSDate extension") {
+        describe("Date extension") {
 
-            let utc = Region(calendarName: .Gregorian, timeZoneName: .Gmt, localeName: .English)
+            let utc = Region(calendarName: .gregorian, timeZoneName: .gmt, localeName: .english)
 
             context("toString UTC") {
 
                 let utcDate = DateInRegion(year: 2015, month: 4, day: 13, hour: 22, minute: 10, region: utc)
 
                 it("should return proper ISO 8601 string") {
-                    expect(utcDate.toString(DateFormat.ISO8601Format(.Full))) == "2015-04-13T22:10:00Z"
+                    expect(utcDate.toString(dateFormat: DateFormat.iso8601Format(.full))) == "2015-04-13T22:10:00Z"
                 }
 
                 it("should return proper ISO 8601 date string") {
-                    expect(utcDate.toString(DateFormat.ISO8601Format(.Date))) == "2015-04-13"
+                    expect(utcDate.toString(dateFormat: DateFormat.iso8601Format(.date))) == "2015-04-13"
                 }
 
 				it("should return proper ISO 8601 (year format) string") {
-					expect(utcDate.toString(DateFormat.ISO8601Format(.Year))) == "2015"
+					expect(utcDate.toString(dateFormat: DateFormat.iso8601Format(.year))) == "2015"
 				}
 
 				it("should return proper ISO 8601 (year/month format) string") {
-					expect(utcDate.toString(DateFormat.ISO8601Format(.YearMonth))) == "2015-04"
+					expect(utcDate.toString(dateFormat: DateFormat.iso8601Format(.yearMonth))) == "2015-04"
 				}
 
 				it("should return proper ISO 8601 (date format) string") {
-					expect(utcDate.toString(DateFormat.ISO8601Format(.Date))) == "2015-04-13"
+					expect(utcDate.toString(dateFormat: DateFormat.iso8601Format(.date))) == "2015-04-13"
 				}
 				
 				it("should return proper ISO 8601 (hour minute) string") {
-					expect(utcDate.toString(DateFormat.ISO8601Format(.HourMinute))) == "22:10"
+					expect(utcDate.toString(dateFormat: DateFormat.iso8601Format(.hourMinute))) == "22:10"
 				}
 				
 				it("should return proper ISO 8601 (time) string") {
-					expect(utcDate.toString(DateFormat.ISO8601Format(.Time))) == "22:10:00"
+					expect(utcDate.toString(dateFormat: DateFormat.iso8601Format(.time))) == "22:10:00"
 				}
 
 				it("should return proper ISO 8601 (date time format) string") {
-					expect(utcDate.toString(DateFormat.ISO8601Format(.DateTime))) == "2015-04-13T22:10Z"
+					expect(utcDate.toString(dateFormat: DateFormat.iso8601Format(.dateTime))) == "2015-04-13T22:10Z"
 				}
 
 				it("should return proper ISO 8601 (full format) string") {
-					expect(utcDate.toString(DateFormat.ISO8601Format(.Full))) == "2015-04-13T22:10:00Z"
+					expect(utcDate.toString(dateFormat: DateFormat.iso8601Format(.full))) == "2015-04-13T22:10:00Z"
 				}
 
 				it("should return proper ISO 8601 (extended with fractional seconds format) string") {
-					expect(utcDate.toString(DateFormat.ISO8601Format(.Extended))) == "2015-04-13T22:10:00.000Z"
+					expect(utcDate.toString(dateFormat: DateFormat.iso8601Format(.extended))) == "2015-04-13T22:10:00.000Z"
 				}
 
                 it("should return proper Alt RSS date string") {
-                    expect(utcDate.toString(DateFormat.AltRSS)) == "13 Apr 2015 22:10:00 +0000"
+                    expect(utcDate.toString(dateFormat: DateFormat.altRSS)) == "13 Apr 2015 22:10:00 +0000"
                 }
 
                 it("should return proper RSS date string") {
-                    expect(utcDate.toString(DateFormat.RSS)) == "Mon, 13 Apr 2015 22:10:00 +0000"
+                    expect(utcDate.toString(dateFormat: DateFormat.rss)) == "Mon, 13 Apr 2015 22:10:00 +0000"
                 }
 
                 it("should return proper custom date string") {
-                    expect(utcDate.toString(DateFormat.Custom("d MMM YY 'at' HH:mm"))) == "13 Apr 15 at 22:10"
+                    expect(utcDate.toString(dateFormat: DateFormat.custom("d MMM YY 'at' HH:mm"))) == "13 Apr 15 at 22:10"
                 }
 
                 it("should return proper custom date string") {
-                    expect(utcDate.toString(DateFormat.Custom("eee d MMM YYYY, m 'minutes after' HH '(timezone is' Z')'"))) == "Mon 13 Apr 2015, 10 minutes after 22 (timezone is +0000)"
+                    expect(utcDate.toString(dateFormat: DateFormat.custom("eee d MMM YYYY, m 'minutes after' HH '(timezone is' Z')'"))) == "Mon 13 Apr 2015, 10 minutes after 22 (timezone is +0000)"
                 }
             }
 
             context("toString local") {
 
-                let date = NSDate(year: 2015, month: 4, day: 13, hour: 22, minute: 10)
+                let date = Date(year: 2015, month: 4, day: 13, hour: 22, minute: 10)
                 let localDate = date.inRegion()
 
                 it("should return proper ISO 8601 string") {
-                    expect(localDate.toString(DateFormat.ISO8601Format(.Full))!.hasPrefix("2015-04-13T22:10:00")) == true
-                    expect(date.toString(DateFormat.ISO8601Format(.Full))!.hasPrefix("2015-04-13T22:10:00")) == true
+                    expect(localDate.toString(dateFormat: DateFormat.iso8601Format(.full))!.hasPrefix("2015-04-13T22:10:00")) == true
+                    expect(date.toString(format: DateFormat.iso8601Format(.full))!.hasPrefix("2015-04-13T22:10:00")) == true
                 }
 
                 it("should return proper ISO 8601 date string") {
-                    expect(localDate.toString(DateFormat.ISO8601Format(.Date))) == "2015-04-13"
-                    expect(date.toString(DateFormat.ISO8601Format(.Date))) == "2015-04-13"
+                    expect(localDate.toString(dateFormat: DateFormat.iso8601Format(.date))) == "2015-04-13"
+                    expect(date.toString(format: DateFormat.iso8601Format(.date))) == "2015-04-13"
                 }
 
                 it("should return proper Alt RSS date string") {
-                    expect(localDate.toString(DateFormat.AltRSS)!.hasPrefix("13 Apr 2015 22:10:00")) == true
-                    expect(date.toString(DateFormat.AltRSS)!.hasPrefix("13 Apr 2015 22:10:00")) == true
+                    expect(localDate.toString(dateFormat: DateFormat.altRSS)!.hasPrefix("13 Apr 2015 22:10:00")) == true
+                    expect(date.toString(format: DateFormat.altRSS)!.hasPrefix("13 Apr 2015 22:10:00")) == true
                 }
 
                 it("should return proper RSS date string") {
-                    expect(localDate.toString(DateFormat.RSS)!.hasPrefix("Mon, 13 Apr 2015 22:10:00")) == true
-                    expect(date.toString(DateFormat.RSS)!.hasPrefix("Mon, 13 Apr 2015 22:10:00")) == true
+                    expect(localDate.toString(dateFormat: DateFormat.rss)!.hasPrefix("Mon, 13 Apr 2015 22:10:00")) == true
+                    expect(date.toString(format: DateFormat.rss)!.hasPrefix("Mon, 13 Apr 2015 22:10:00")) == true
                 }
 
                 it("should return proper custom date string") {
-                    expect(localDate.toString(DateFormat.Custom("d MMM YY 'at' HH:mm"))) == "13 Apr 15 at 22:10"
-                    expect(date.toString(DateFormat.Custom("d MMM YY 'at' HH:mm"))) == "13 Apr 15 at 22:10"
+                    expect(localDate.toString(dateFormat: DateFormat.custom("d MMM YY 'at' HH:mm"))) == "13 Apr 15 at 22:10"
+                    expect(date.toString(format: DateFormat.custom("d MMM YY 'at' HH:mm"))) == "13 Apr 15 at 22:10"
                 }
 
                 it("should return proper custom date string") {
-                    expect(localDate.toString(DateFormat.Custom("eee d MMM YYYY, m 'minutes after' HH '(timezone is' Z')'"))!.hasPrefix("Mon 13 Apr 2015, 10 minutes after 22 (timezone is ")) == true
-                    expect(date.toString(DateFormat.Custom("eee d MMM YYYY, m 'minutes after' HH '(timezone is' Z')'"))!.hasPrefix("Mon 13 Apr 2015, 10 minutes after 22 (timezone is ")) == true
+                    expect(localDate.toString(dateFormat: DateFormat.custom("eee d MMM YYYY, m 'minutes after' HH '(timezone is' Z')'"))!.hasPrefix("Mon 13 Apr 2015, 10 minutes after 22 (timezone is ")) == true
+                    expect(date.toString(format: DateFormat.custom("eee d MMM YYYY, m 'minutes after' HH '(timezone is' Z')'"))!.hasPrefix("Mon 13 Apr 2015, 10 minutes after 22 (timezone is ")) == true
                 }
             }
         }

--- a/Sources/SwiftDateTests/RegionTests.swift
+++ b/Sources/SwiftDateTests/RegionTests.swift
@@ -19,33 +19,33 @@ class DateregionSpec: QuickSpec {
         describe("Region") {
 
             let region = Region()
-            let india = Region(calendarName: .Indian, timeZoneName: .AsiaKolkata, localeName: .HindiIndia)
-            let jerusalem = Region(calendarName: .Hebrew, timeZoneName: .AsiaJerusalem, localeName: .HebrewIsrael)
+            let india = Region(calendarName: .indian, timeZoneName: .asiaKolkata, localeName: .hindiIndia)
+            let jerusalem = Region(calendarName: .hebrew, timeZoneName: .asiaJerusalem, localeName: .hebrewIsrael)
 
             context("initialisation") {
 
                 it("should have the default time zone & locale in the current calendar") {
-                    expect(region.calendar.calendarIdentifier) == NSCalendar.currentCalendar().calendarIdentifier
-                    expect(region.timeZone.abbreviation) == NSTimeZone.defaultTimeZone().abbreviation
-                    expect(region.locale.localeIdentifier) == NSLocale.currentLocale().localeIdentifier
-                    expect(region.calendar.timeZone.abbreviation) == NSTimeZone.defaultTimeZone().abbreviation
-                    expect(region.calendar.locale?.localeIdentifier) == NSLocale.currentLocale().localeIdentifier
+                    expect(region.calendar.identifier) == Calendar.current.identifier
+                    expect(region.timeZone.abbreviation()) == TimeZone.current.abbreviation()
+                    expect(region.locale.identifier) == Locale.current.identifier
+                    expect(region.calendar.timeZone.abbreviation()) == TimeZone.current.abbreviation()
+                    expect(region.calendar.locale?.identifier) == Locale.current.identifier
                 }
 
                 it("should have the specified calendar") {
-                    expect(jerusalem.calendar) == NSCalendar(calendarIdentifier: NSCalendarIdentifierHebrew)!
+                    expect(jerusalem.calendar) == Calendar(identifier: Calendar.Identifier.hebrew)
                 }
 
                 it("should have the specified time zone") {
-                    expect(jerusalem.timeZone) == NSTimeZone(name: "Asia/Jerusalem")
+                    expect(jerusalem.timeZone) == TimeZone(identifier: "Asia/Jerusalem")
                 }
 
                 it("should have the specified time zone") {
-                    expect(india.timeZone.name) == TimeZoneName.AsiaKolkata.description
+                    expect(india.timeZone.identifier) == TimeZoneName.asiaKolkata.description
                 }
 
                 it("should have the specified locale") {
-                    expect(jerusalem.locale) == NSLocale(localeIdentifier: "he_IL")
+                    expect(jerusalem.locale) == Locale(identifier: "he_IL")
                 }
             }
 
@@ -88,22 +88,22 @@ class DateregionSpec: QuickSpec {
                 }
 
                 it("should return false when unequal calendars") {
-                    let region1 = Region(calendarName: .Islamic)
-                    let region2 = Region(calendarName: .IslamicCivil)
+                    let region1 = Region(calendarName: .islamic)
+                    let region2 = Region(calendarName: .islamicCivil)
 
                     expect(region1) != region2
                 }
 
                 it("should return false when unequal time zones") {
-                    let region1 = Region(timeZoneName: .AmericaKralendijk)
-                    let region2 = Region(timeZoneName: .AfricaWindhoek)
+                    let region1 = Region(timeZoneName: .americaKralendijk)
+                    let region2 = Region(timeZoneName: .africaWindhoek)
 
                     expect(region1) != region2
                 }
 
                 it("should return false when unequal locales") {
-                    let region1 = Region(localeName: .HausaNiger)
-                    let region2 = Region(localeName: .EnglishFiji)
+                    let region1 = Region(localeName: .hausaNiger)
+                    let region2 = Region(localeName: .englishFiji)
 
                     expect(region1) != region2
                 }

--- a/XCode/Cartfile.private
+++ b/XCode/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick"
-github "Quick/Nimble"
+github "Quick/Quick" "swift-3.0"
+github "Quick/Nimble" "master"

--- a/XCode/Cartfile.resolved
+++ b/XCode/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v4.0.0"
-github "Quick/Quick" "v0.9.2"
+github "Quick/Nimble" "db706fc1d7130f6ac96c56aaf0e635fa3217fe57"
+github "Quick/Quick" "8f2bc636ecfa2cc20696f62548b38d4ab943e299"

--- a/XCode/SwiftDate.xcodeproj/project.pbxproj
+++ b/XCode/SwiftDate.xcodeproj/project.pbxproj
@@ -514,9 +514,11 @@
 				TargetAttributes = {
 					1FAA83911C79C6DA0084BAB6 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0800;
 					};
 					1FAA839A1C79C6DA0084BAB6 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0800;
 					};
 					90F1F3881C7F6AF500B22B90 = {
 						CreatedOnToolsVersion = 7.3;
@@ -861,6 +863,7 @@
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -884,6 +887,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.houtzager.SwiftDate;
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -902,6 +906,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.houtzager.SwiftDateTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -918,6 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.houtzager.SwiftDateTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
I migrated SwiftDate's unit tests to Swift 3 so that I could work on #248. 

It looks like Quick and Nimble do not have official Swift 3 releases so I've update the Cartfile to use specific Swift 3.0 branches. Unfortunately, there are three compile errors regarding Nimble that I was unable to fix:

<img width="357" alt="screen shot 2016-09-17 at 7 38 57 pm" src="https://cloud.githubusercontent.com/assets/3449816/18611687/dfb36e1c-7d0e-11e6-8d97-a3e16791a27e.png">

I commented out those failing lines (locally) and ran the test suite: there were lots of failures. The majority of the failures I believe is a 🐛 in Swift where DateComponent returns `Int.max` when a component is not specified (instead of nil).  [SR-2671](https://bugs.swift.org/browse/SR-2671?jql=text%20~%20%22DateComponent%22) 

This is the bug causing the issue reported in #248. I implemented a work around to check for `Int.max` when getting a value from a DateComponent.

Please note that there are still ~20 failing tests at the moment (mostly string formatting errors).

Any additional help to fix the remaining compile issues and tests is greatly appreciated.


