### PR TITLE
Fixed some broken tests in Swift 3.0.

### DIFF
--- a/Sources/SwiftDate/DateComponents+SwiftDate.swift
+++ b/Sources/SwiftDate/DateComponents+SwiftDate.swift
@@ -171,7 +171,12 @@ internal func sumDateComponents(lhs: DateComponents, rhs: DateComponents, sum: B
 
         guard let leftValue = lhs.value(for: component),
             let rightValue = rhs.value(for: component) else {
-            continue // both are undefined, don't touch
+                continue // both are nil, don't touch
+        }
+
+        guard leftValue != DateComponents.undefined ||
+            rightValue != DateComponents.undefined else {
+                continue // both are undefined, don't touch
         }
 
         let checkedLeftValue = leftValue != DateComponents.undefined ? leftValue : 0

--- a/Sources/SwiftDate/DateInRegion.swift
+++ b/Sources/SwiftDate/DateInRegion.swift
@@ -392,7 +392,7 @@ extension DateInRegion: CustomDebugStringConvertible {
 		var descriptor: [String] = []
 
 		let formatter = FoundationDateFormatter()
-		formatter.dateStyle = .medium
+		formatter.dateStyle = .long
 		formatter.timeStyle = .long
 		formatter.locale = self.locale
 		formatter.calendar = self.calendar

--- a/Sources/SwiftDateTests/DateInRegionComponentPortTests.swift
+++ b/Sources/SwiftDateTests/DateInRegionComponentPortTests.swift
@@ -56,7 +56,7 @@ class DateInRegionComponentPortSpec: QuickSpec {
                 }
 
                 it("should report a valid nanosecond") {
-                    expect(date.value(for: .nanosecond)).to(beCloseTo(87654321, within: 10))
+                    expect(Double(date.value(for: .nanosecond))).to(beCloseTo(87654321, within: 10))
                 }
 
             }

--- a/Sources/SwiftDateTests/DateInRegionTests.swift
+++ b/Sources/SwiftDateTests/DateInRegionTests.swift
@@ -457,7 +457,7 @@ class DateInRegionSpec: QuickSpec {
                     expect(date!.hour) == 14
                     expect(date!.minute) == 26
                     expect(date!.second) == 08
-                    expect(date!.nanosecond).to(beCloseTo(123000000, within: 100))
+                    expect(Double(date!.nanosecond)).to(beCloseTo(123000000, within: 100))
                     expect(date!.timeZone.secondsFromGMT()) == 0
                 }
 

--- a/Sources/SwiftDateTests/NSDateComponentPortTests.swift
+++ b/Sources/SwiftDateTests/NSDateComponentPortTests.swift
@@ -55,7 +55,7 @@ class NSDateComponentPortSpec: QuickSpec {
                 }
 
                 it("should report a valid nanosecond") {
-                    expect(date.nanosecond).to(beCloseTo(87654321, within: 10))
+                    expect(Double(date.nanosecond)).to(beCloseTo(87654321, within: 10))
                 }
 
             }

--- a/Sources/SwiftDateTests/NSDateComponentPortTests.swift
+++ b/Sources/SwiftDateTests/NSDateComponentPortTests.swift
@@ -127,8 +127,8 @@ class NSDateComponentPortSpec: QuickSpec {
                     expect(components.year) == 2002
                     expect(components.month) == 6
                     expect(components.day) == 23
-                    expect(components.hour) == nil
-                    expect(components.minute) == nil
+                    expect(components.hour).to(beNil())
+                    expect(components.minute).to(beNil())
                 }
 
                 it("should return a midnight date YMD initialisation (winter)") {

--- a/XCode/Cartfile.private
+++ b/XCode/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" "swift-3.0"
-github "Quick/Nimble" "master"
+github "Quick/Quick" "master"
+github "Quick/Nimble"

--- a/XCode/Cartfile.resolved
+++ b/XCode/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "db706fc1d7130f6ac96c56aaf0e635fa3217fe57"
-github "Quick/Quick" "8f2bc636ecfa2cc20696f62548b38d4ab943e299"
+github "Quick/Nimble" "v5.0.0"
+github "Quick/Quick" "ddd6036187e3cb0bc53bea1e8e7951b61a55304d"


### PR DESCRIPTION
- [x] Fixed compile 🐛 with Test target. Test target now compiles! 👏
- [x] Fixed failing tests that were using `== nil` to use Nimble's `beNil` matcher.
- [x] Fixed test for the debugDescription by reverting date style back to [`.long`](https://github.com/malcommac/SwiftDate/pull/241/files#diff-d86cf348448077fe7d28198c6ac6b35dL396)
- [x] Fixed "summing date components" by not adding component when both values are undefined.