### PR TITLE
Remove `throws` from Date.add(components:) in Date+Math.swift

### DIFF
--- a/Sources/SwiftDate/Date+Math.swift
+++ b/Sources/SwiftDate/Date+Math.swift
@@ -58,7 +58,7 @@ public extension Date {
 	/// - throws: throw an exception if new date cannot be evaluated
 	///
 	/// - returns: a new `Date`
-	public func add(components: DateComponents) throws -> Date {
+	public func add(components: DateComponents) -> Date {
 		let date: DateInRegion = self.inGMTRegion() + components
 		return date.absoluteDate
 	}
@@ -70,7 +70,7 @@ public extension Date {
 	/// - throws: throw an exception if new date cannot be evaluated
 	///
 	/// - returns: a new `Date`
-	public func add(components: [Calendar.Component: Int]) throws -> Date {
+	public func add(components: [Calendar.Component: Int]) -> Date {
 		let date: DateInRegion = self.inGMTRegion() + components
 		return date.absoluteDate
 	}
@@ -84,7 +84,7 @@ public func - (lhs: Date, rhs: DateComponents) -> Date {
 }
 
 public func + (lhs: Date, rhs: DateComponents) -> Date {
-	return try! lhs.add(components: rhs)
+	return lhs.add(components: rhs)
 }
 
 public func + (lhs: Date, rhs: TimeInterval) -> Date {
@@ -96,11 +96,11 @@ public func - (lhs: Date, rhs: TimeInterval) -> Date {
 }
 
 public func + (lhs: Date, rhs: [Calendar.Component : Int]) -> Date {
-	return try! lhs.add(components: DateInRegion.componentsFrom(values: rhs))
+	return lhs.add(components: DateInRegion.componentsFrom(values: rhs))
 }
 
 public func - (lhs: Date, rhs: [Calendar.Component : Int]) -> Date {
-	return try! lhs.add(components: DateInRegion.componentsFrom(values: rhs, multipler: -1))
+	return lhs.add(components: DateInRegion.componentsFrom(values: rhs, multipler: -1))
 }
 
 public func - (lhs: Date, rhs: Date) -> TimeInterval {


### PR DESCRIPTION
Hi!
I removed `throws` from `Date.add(components:)` in Date+Math.swift because it's impossible to catch errors throws from `Date.add(components:)` because `Error` occurs when implicitly unwrap optional at [`DateInRegion+Math.swift`](https://github.com/malcommac/SwiftDate/blob/master/Sources/SwiftDate/DateInRegion%2BMath.swift#L63) fails.
See the sample screenshot below.

<img width="631" alt="screen shot 2016-10-04 at 10 44 54" src="https://cloud.githubusercontent.com/assets/2959791/19060038/a4eb0100-8a1f-11e6-9907-343bb1ef86ac.png">


I appreciate you would review this pull request.

Thanks!