### PR TITLE
Fix bug #315: Date().add(components:) doesn't work when daylight savi…

### DIFF
--- a/Sources/SwiftDate/Date+Math.swift
+++ b/Sources/SwiftDate/Date+Math.swift
@@ -59,7 +59,7 @@ public extension Date {
 	///
 	/// - returns: a new `Date`
 	public func add(components: DateComponents) -> Date {
-		let date: DateInRegion = self.inGMTRegion() + components
+		let date: DateInRegion = self.inDateDefaultRegion() + components
 		return date.absoluteDate
 	}
 	
@@ -71,7 +71,7 @@ public extension Date {
 	///
 	/// - returns: a new `Date`
 	public func add(components: [Calendar.Component: Int]) -> Date {
-		let date: DateInRegion = self.inGMTRegion() + components
+		let date: DateInRegion = self.inDateDefaultRegion() + components
 		return date.absoluteDate
 	}
 	


### PR DESCRIPTION
Date().add(components:) should use dateDefaultRegion for addition operation instead of GMTRegion.
