### PR TITLE
Calculate date based on default region

### DIFF
--- a/Sources/SwiftDate/Date+Math.swift
+++ b/Sources/SwiftDate/Date+Math.swift
@@ -55,11 +55,9 @@ public extension Date {
 	///
 	/// - parameter components: components to set
 	///
-	/// - throws: throw an exception if new date cannot be evaluated
-	///
 	/// - returns: a new `Date`
 	public func add(components: DateComponents) -> Date {
-		let date: DateInRegion = self.inGMTRegion() + components
+		let date: DateInRegion = self.inDateDefaultRegion() + components
 		return date.absoluteDate
 	}
 	
@@ -67,11 +65,9 @@ public extension Date {
 	///
 	/// - parameter components: components to set
 	///
-	/// - throws: throw an exception if new date cannot be evaluated
-	///
 	/// - returns: a new `Date`
 	public func add(components: [Calendar.Component: Int]) -> Date {
-		let date: DateInRegion = self.inGMTRegion() + components
+		let date: DateInRegion = self.inDateDefaultRegion() + components
 		return date.absoluteDate
 	}
 	


### PR DESCRIPTION
In my case, the result of calculation two Dates is wrong when I use GMT region.
So, I want to calculate based on default region.

for example (I'm in Japan, UTC+9): 
```
let december = try! Date().at(unitsWithValues: [.year: 2016, .month: 12]).startOf(component: .month)
let january = (december + 1.month)
        
print(december) 
print(january)
```

Console log:
```
2016-11-30 15:00:00 +0000
2016-12-30 15:00:00 +0000 // It is wrong result
```