### PR TITLE
Brazilian Portuguese support

### DIFF
--- a/Sources/SwiftDate/LocaleName.swift
+++ b/Sources/SwiftDate/LocaleName.swift
@@ -570,7 +570,7 @@ public enum LocaleName: String {
 	case polishPoland = "pl_PL"
 	case portuguese = "pt"
 	case portugueseAngola = "pt_AO"
-	case portugueseBrazil = "pt_BR"
+	case portugueseBrazil = "pt"
 	case portugueseCapeVerde = "pt_CV"
 	case portugueseGuineaBissau = "pt_GW"
 	case portugueseMacauSarChina = "pt_MO"

--- a/Sources/SwiftDate/SwiftDate.bundle/pt.lproj/SwiftDate.strings
+++ b/Sources/SwiftDate/SwiftDate.bundle/pt.lproj/SwiftDate.strings
@@ -1,0 +1,49 @@
+//Brazillian Portuguese
+// COLLOQUIAL STRINGS
+"colloquial_f_y"					=	"ano que vem";		// year,future,singular: 	"ano que vem"
+"colloquial_f_yy"					=	"em %d";			// year,future,plural:		"em 2016"
+"colloquial_p_y"					=	"ano passado";		// year,past,singular:		"ano passado"
+"colloquial_p_yy"					=	"%d";				// year,past,plural:		"2015"
+
+"colloquial_f_m"					=	"mês que vem";		// month,future,singular:	"mês que vem"
+"colloquial_f_mm"					=	"em %d meses";		// month,future,plural:		"em 3 meses"
+"colloquial_p_m"					=	"mês passado";		// month,past,singular:		"mês passado"
+"colloquial_p_mm"					=	"%d meses atrás";	// month,past,plural:		"3 meses atrás"
+
+"colloquial_f_w"					=	"semana que vem";	// week,future,singular:	"semana que vem"
+"colloquial_f_ww"					=	"em %d semanas";	// week,future,plural:		"em 3 semanas"
+"colloquial_p_w"					=	"semana passada";	// week,past,singular:		"semana passada"
+"colloquial_p_ww"					=	"%d semanas atrás";	// week,past,plural:		"3 semanas atrás"
+
+"colloquial_f_d"					=	"amanhã";			// day,future,singular:		"amanhã"
+"colloquial_f_dd"					=	"em %d dias";		// day,future,plural:		"em 3 dias"
+"colloquial_p_d"					=	"ontem";            // day,past,singular:		"ontem"
+"colloquial_p_dd"					=	"%d dias atrás";	// day,past,plural:			"3 dias atrás"
+
+"colloquial_f_h"					=	"em uma hora";		// hour,future,singular:	"em uma hora"
+"colloquial_f_hh"					=	"em %d horas";		// hour,future,plural:		"em 3 horas"
+"colloquial_p_h"					=	"uma hora atrás";	// hour,past,singular:		"uma hora atrás"
+"colloquial_p_hh"					=	"%d horas atrás";	// hour,past,plural:		"3 horas atrás"
+
+"colloquial_f_M"					=	"em um minuto";     // minute,future,singular:	"em um minuto"
+"colloquial_f_MM"					=	"em %d minutos";	// minute,future,plural:	"em 3 minutos"
+"colloquial_p_M"					=	"um minuto atrás";	// minute,past,singular:	"um minuto atrás"
+"colloquial_p_MM"					=	"%d minutos atrás";	// minute,past,plural:		"3 minutos atrás"
+
+"colloquial_now"					=	"agora pouco";		// less than 5 minutes if .allowsNowOnColloquial is set
+
+// RELEVANT TIME TO PRINT ALONG COLLOQUIAL STRING WHEN .includeRelevantTime = true
+"relevanttime_y"					=	"MMM yyyy";			// for colloquial year (=+-1) adds a time string like this:"(Fev 2016)"
+"relevanttime_yy"					=	"MMM yyyy";			// for colloquial years (>1) adds a time string like this:"(Fev 2016)"
+"relevanttime_m"					=	"dd, MMM yyyy";		// for colloquial month (=+-1) adds a time string like this:"(17 Fev, 2016)"
+"relevanttime_mm"					=	"dd, MMM yyyy";		// for colloquial months (>1) adds a time string like this: "(17 Fev, 2016)"
+"relevanttime_w"					=	"EEE, MMM dd";		// for colloquial months (>1) adds a time string like this: "(Qua Fev 17)"
+"relevanttime_ww"					=	"EEE, MMM dd";		// for colloquial months (>1) adds a time string like this: "(Qua Fev 17)"
+"relevanttime_d"					=	"EEE, MMM dd";		// for colloquial day (=+-1) adds a time string like this: "(Qua Fev 17)"
+"relevanttime_dd"					=	"EEE, MMM dd";		// for colloquial days (>1) adds a time string like this: "(Qua Fev 17)"
+"relevanttime_h"					=	"'às' HH:mm";		// for colloquial day (=+-1) adds a time string like this: "(At 13:20)"
+"relevanttime_hh"					=	"'às' HH:mm";		// for colloquial days (>1) adds a time string like this: "(At 13:20)"
+"relevanttime_M"					=	"";					// for colloquial minute(s) we have not any relevant time to print
+"relevanttime_MM"					=	"";					// for colloquial minute(s) we have not any relevant time to print
+"relevanttime_s"					=	"";					// for colloquial seconds(s) we have not any relevant time to print
+"relevanttime_ss"					=	"";					// for colloquial seconds(s) we have not any relevant time to print


### PR DESCRIPTION
- Updated locale identifier*
- Brazillian Portuguese (pt) localization

*Since iOS 8 `pt_BR` has become `pt`

Reference:

> The language ID for scripts or dialects uses subtags, as in pt-PT where pt is the code for Portuguese and PT is the code for Portugal. For example, use pt as the language ID for Portuguese as it is used in Brazil and pt-PT as the language ID for Portuguese as it is used in Portugal.


https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/LocalizingYourApp/LocalizingYourApp.html
