### PR TITLE
Gets rid of negative colloquial strings

### DIFF
--- a/Sources/SwiftDate/DateInRegion+Formatter.swift
+++ b/Sources/SwiftDate/DateInRegion+Formatter.swift
@@ -159,7 +159,7 @@ public extension DateInRegion {
 	///
 	/// - returns: string with each time component
 	public func timeComponentsSinceNow(options: ComponentsFormatterOptions? = nil) throws -> String {
-		let interval = self.absoluteDate.timeIntervalSinceNow
+		let interval = abs(self.absoluteDate.timeIntervalSinceNow)
 		var optionsStruct = (options == nil ? ComponentsFormatterOptions() : options!)
 		optionsStruct.locale = self.region.locale
 		return try interval.string(options: optionsStruct, shared: self.formatters.useSharedFormatters)

--- a/Tests/SwiftDateTests/TestDateInRegion+Formatter.swift
+++ b/Tests/SwiftDateTests/TestDateInRegion+Formatter.swift
@@ -84,7 +84,7 @@ class TestDateInRegion_Formatter: XCTestCase {
         componentFormatterOptions.style = .short
         componentFormatterOptions.zeroBehavior = .dropAll
         let custom_5 = try! another_Date.timeComponentsSinceNow(options: componentFormatterOptions)
-		XCTAssertEqual(custom_5, "2 hr,5 min,3 sec", "Failed get colloquial representation of an old date")
+		XCTAssertEqual(custom_5, "2 hr, 5 min, 3 sec", "Failed get colloquial representation of an old date")
 	}
 
 	public func test_iso8601_formatter() {


### PR DESCRIPTION
Running this code:

```swift
let another_Date = DateInRegion(absoluteDate: Date()) - 2.hours - 5.minutes - 3.seconds
var componentFormatterOptions = ComponentsFormatterOptions()
componentFormatterOptions.style = .short
componentFormatterOptions.zeroBehavior = .dropAll
let custom_5 = try! another_Date.timeComponentsSinceNow(options: componentFormatterOptions)
```

Would result in `custom_5 == "-2 hr, 5 min, 3 sec"` instead of `"2 hr, 5 min, 3 sec"`. Also added the spaces to the tests so it would pass.