### PR TITLE
DateTimeInterval#duration returns a wrong value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ## SwiftDate 4.1.7
 ---
-- **Release Date**: -
+- **Release Date**: 2017-07-16
 - **Zipped Version**: [Download 4.1.7](https://github.com/malcommac/SwiftDate/releases/tag/4.1.7)
 
 #### New Features

--- a/Sources/SwiftDate/DateTimeInterval.swift
+++ b/Sources/SwiftDate/DateTimeInterval.swift
@@ -64,7 +64,8 @@ public struct DateTimeInterval : Comparable {
 	/// Initialize a `DateTimeInterval` with the specified start and end date.
 	public init(start: Date, end: Date) {
 		self.start = start
-		duration = start.timeIntervalSince(end)
+		precondition(end >= start, "Reverse intervals are not allowed")
+		duration = end.timeIntervalSince(start)
 	}
 	
 	/// Initialize a `DateTimeInterval` with the specified start date and duration.


### PR DESCRIPTION
`DateTimeInterval#duration` returns a negative value when it is initialized with values.
This means `DateTimeInterval#end` is not equal to the init value.
(iOS10 `DateInterval` can return correct values.)