### PR TITLE
Updates project settings for Swift 4, corrects range() call

### DIFF
--- a/Sources/SwiftDate/DOTNETDateTimeFormatter.swift
+++ b/Sources/SwiftDate/DOTNETDateTimeFormatter.swift
@@ -44,10 +44,10 @@ public class DOTNETDateTimeFormatter {
 				return nil
 			}
 			
-			guard let milliseconds = TimeInterval((string as NSString).substring(with: match.rangeAt(1))) else { return nil }
+            guard let milliseconds = TimeInterval((string as NSString).substring(with: match.range(at: 1))) else { return nil }
 			
 			// Parse timezone
-			let raw_tz = ((string as NSString).substring(with: match.rangeAt(2)) as NSString)
+            let raw_tz = ((string as NSString).substring(with: match.range(at: 2)) as NSString)
 			guard raw_tz.length > 1 else {
 				return nil
 			}

--- a/SwiftDate/SwiftDate.xcodeproj/project.pbxproj
+++ b/SwiftDate/SwiftDate.xcodeproj/project.pbxproj
@@ -731,7 +731,7 @@
 				SUPPORTED_PLATFORMS = "macosx iphoneos appletvos watchos appletvsimulator iphonesimulator watchsimulator";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-iOS.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -759,7 +759,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphoneos appletvos watchos appletvsimulator iphonesimulator watchsimulator";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-iOS.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -833,6 +833,7 @@
 				64E64C261EEC50C3000970BF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
## What Changed and Why

This PR updates the project settings for Xcode to allow `SwiftDate` to build when `Swift 4` is selected as the `Swift Language Version` in a project.

## Screenshot

![screenshot 2017-08-25 09 40 01](https://user-images.githubusercontent.com/728690/29716430-637026c4-8979-11e7-9f50-df11e8e3f46d.png)

## Testing
- [ ] Do a complete clean of the project.
- [ ] Rebuild the project under the default scheme, there should be no errors.