### PR TITLE
Disabled code coverage

### DIFF
--- a/SwiftDate.xcodeproj/xcshareddata/xcschemes/SwiftDate-iOS.xcscheme
+++ b/SwiftDate.xcodeproj/xcshareddata/xcschemes/SwiftDate-iOS.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/SwiftDate.xcodeproj/xcshareddata/xcschemes/SwiftDate-macOS.xcscheme
+++ b/SwiftDate.xcodeproj/xcshareddata/xcschemes/SwiftDate-macOS.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/SwiftDate.xcodeproj/xcshareddata/xcschemes/SwiftDate-tvOS.xcscheme
+++ b/SwiftDate.xcodeproj/xcshareddata/xcschemes/SwiftDate-tvOS.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/SwiftDate.xcodeproj/xcshareddata/xcschemes/SwiftDate-watchOS.xcscheme
+++ b/SwiftDate.xcodeproj/xcshareddata/xcschemes/SwiftDate-watchOS.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <AdditionalOptions>


### PR DESCRIPTION
I wasn't able to upload my app with SwiftDate and Carthage to iTunes Connect using Xcode 9, I got this message and I'm not able to continue uploading:

> Invalid Bundle - Disallowed LLVM instrumentation. Do not submit apps with LLVM profiling instrumentation or coverage collection enabled. Turn off LLVM profiling or code coverage, rebuild your app and resubmit the app.

It seems like they have this validation since Xcode 9. When I remove the code coverage checkmark the message does not appear anymore and the upload is successful. 

[https://forums.developer.apple.com/thread/81893](https://forums.developer.apple.com/thread/81893)