### PR TITLE
Add Polish translations

### DIFF
--- a/Sources/SwiftDate/SwiftDate.bundle/pl-PL.lproj/Localizable.stringsdict
+++ b/Sources/SwiftDate/SwiftDate.bundle/pl-PL.lproj/Localizable.stringsdict
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>colloquial_f_mm</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@VARIABLE@</string>
+		<key>VARIABLE</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>za %d miesięcy</string>
+			<key>one</key>
+			<string>za miesiąc</string>
+			<key>two</key>
+			<string>za %d miesiące</string>
+			<key>few</key>
+			<string>za %d miesięce</string>
+			<key>many</key>
+			<string>za %d miesięcy</string>
+			<key>other</key>
+			<string>za %d miesięcy</string>
+		</dict>
+	</dict>
+	<key>colloquial_p_mm</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@VARIABLE@</string>
+		<key>VARIABLE</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d miesięcy temu</string>
+			<key>one</key>
+			<string>miesiąc temu</string>
+			<key>two</key>
+			<string>%d miesiące temu</string>
+			<key>few</key>
+			<string>%d miesięce temu</string>
+			<key>many</key>
+			<string>%d miesięcy temu</string>
+			<key>other</key>
+			<string>%d miesięcy temu</string>
+		</dict>
+	</dict>
+	<key>colloquial_f_ww</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@VARIABLE@</string>
+		<key>VARIABLE</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>za %d tygodni</string>
+			<key>one</key>
+			<string>za tydzień</string>
+			<key>two</key>
+			<string>za %d tygodnie</string>
+			<key>few</key>
+			<string>za %d tygodnie</string>
+			<key>many</key>
+			<string>za %d tygodni</string>
+			<key>other</key>
+			<string>za %d tygodni</string>
+		</dict>
+	</dict>
+	<key>colloquial_p_ww</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@VARIABLE@</string>
+		<key>VARIABLE</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d tygodni temu</string>
+			<key>one</key>
+			<string>tydzień temu</string>
+			<key>two</key>
+			<string>%d tygodnie temu</string>
+			<key>few</key>
+			<string>%d tygodnie temu</string>
+			<key>many</key>
+			<string>%d tygodni temu</string>
+			<key>other</key>
+			<string>%d tygodni temu</string>
+		</dict>
+	</dict>
+	<key>colloquial_f_dd</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@VARIABLE@</string>
+		<key>VARIABLE</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>za %d dni</string>
+			<key>one</key>
+			<string>za %d dzień</string>
+			<key>two</key>
+			<string>za %d dni</string>
+			<key>few</key>
+			<string>za %d dni</string>
+			<key>many</key>
+			<string>za %d dni</string>
+			<key>other</key>
+			<string>za %d dni</string>
+		</dict>
+	</dict>
+	<key>colloquial_p_dd</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@VARIABLE@</string>
+		<key>VARIABLE</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d dni temu</string>
+			<key>one</key>
+			<string>%d dzień temu</string>
+			<key>two</key>
+			<string>%d dni temu</string>
+			<key>few</key>
+			<string>%d dni temu</string>
+			<key>many</key>
+			<string>%d dni temu</string>
+			<key>other</key>
+			<string>%d dni temu</string>
+		</dict>
+	</dict>
+	<key>colloquial_f_hh</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@VARIABLE@</string>
+		<key>VARIABLE</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>za %d godzin</string>
+			<key>one</key>
+			<string>za godzinę</string>
+			<key>two</key>
+			<string>za %d godziny</string>
+			<key>few</key>
+			<string>za %d godziny</string>
+			<key>many</key>
+			<string>za %d godzin</string>
+			<key>other</key>
+			<string>za %d godzin</string>
+		</dict>
+	</dict>
+	<key>colloquial_p_hh</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@VARIABLE@</string>
+		<key>VARIABLE</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d godzin temu</string>
+			<key>one</key>
+			<string>godzinę temu</string>
+			<key>two</key>
+			<string>%d godziny temu</string>
+			<key>few</key>
+			<string>%d godziny temu</string>
+			<key>many</key>
+			<string>%d godzin temu</string>
+			<key>other</key>
+			<string>%d godzin temu</string>
+		</dict>
+	</dict>
+	<key>colloquial_f_MM</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@VARIABLE@</string>
+		<key>VARIABLE</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>za %d minut</string>
+			<key>one</key>
+			<string>za minutę</string>
+			<key>two</key>
+			<string>za %d minuty</string>
+			<key>few</key>
+			<string>za %d minuty</string>
+			<key>many</key>
+			<string>za %d minut</string>
+			<key>other</key>
+			<string>za %d minut</string>
+		</dict>
+	</dict>
+	<key>colloquial_p_MM</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@VARIABLE@</string>
+		<key>VARIABLE</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minut temu</string>
+			<key>one</key>
+			<string>minutę temu</string>
+			<key>two</key>
+			<string>%d minuty temu</string>
+			<key>few</key>
+			<string>%d minut temu</string>
+			<key>many</key>
+			<string>%d minut temu</string>
+			<key>other</key>
+			<string>%d minut temu</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Sources/SwiftDate/SwiftDate.bundle/pl-PL.lproj/SwiftDate.strings
+++ b/Sources/SwiftDate/SwiftDate.bundle/pl-PL.lproj/SwiftDate.strings
@@ -1,0 +1,56 @@
+// COLLOQUIAL STRINGD
+"colloquial_f_y"					=	"w przyszłym roku";		// year,future,singular: 	"next year"
+"colloquial_f_yy"					=	"w %d";			// year,future,plural:		"on 2016"
+"colloquial_p_y"					=	"w zeszłym roku";		// year,past,singular:		"last year"
+"colloquial_p_yy"					=	"%d";				// year,past,plural:		"2015"
+
+"colloquial_f_m"					=	"w przyszłym miesiącu";		// month,future,singular:	"next month"
+"colloquial_f_mm"					=	"za %d miesiące";		// month,future,plural:		"in 3 months" // Recommended use of Localizable.stringsdict file
+"colloquial_p_m"					=	"w zeszłym miesiącu";		// month,past,singular:		"past month"
+"colloquial_p_mm"					=	"%d miesięcy temu";	// month,past,plural:		"3 months ago" // Recommended use of Localizable.stringsdict file
+
+"colloquial_f_w"					=	"w przyszłym tygodniu";		// week,future,singular:	"next week"
+"colloquial_f_ww"					=	"za %d tygodnie";		// week,future,plural:		"in 3 weeks" // Recommended use of Localizable.stringsdict file
+"colloquial_p_w"					=	"tydzień temu";		// week,past,singular:		"past week"
+"colloquial_p_ww"					=	"%d tygodni temu";		// week,past,plural:		"in 3 weeks" // Recommended use of Localizable.stringsdict file
+
+"colloquial_f_d"					=	"jutro";			// day,future,singular:		"tomorrow"
+"colloquial_f_dd"					=	"za %d dni";		// day,future,plural:		"in 3 days" // Recommended use of Localizable.stringsdict file
+"colloquial_p_d"					=	"wczoraj";		// day,past,singular:		"yesterday"
+"colloquial_p_dd"					=	"%d dni temu";		// day,past,plural:			"3 days ago" // Recommended use of Localizable.stringsdict file
+
+"colloquial_f_h"					=	"za godzinę";		// hour,future,singular:	"in one hour"
+"colloquial_f_hh"					=	"za %d godziny";		// hour,future,plural:		"in 3 hours" // Recommended use of Localizable.stringsdict file
+"colloquial_p_h"					=	"godzinę temu";		// hour,past,singular:		"one hour ago"
+"colloquial_p_hh"					=	"%d godziny temu";		// hour,past,plural:		"3 hours ago" // Recommended use of Localizable.stringsdict file
+
+"colloquial_f_M"					=	"za minutę";	// minute,future,singular:	"in one minute"
+"colloquial_f_MM"					=	"za %d minuty";	// minute,future,plural:	"in 3 minutes" // Recommended use of Localizable.stringsdict file
+"colloquial_p_M"					=	"minutę temu";	// minute,past,singular:	"one minute ago"
+"colloquial_p_MM"					=	"%d minuty temu";	// minute,past,plural:		"3 minutes ago" // Recommended use of Localizable.stringsdict file
+
+"colloquial_now"					=	"właśnie";			// less than 5 minutes if .allowsNowOnColloquial is set
+
+"colloquial_n_0y"					=	"w tym roku";		// this year
+"colloquial_n_0m"					=	"w tym miesiącu";		// this month
+"colloquial_n_0w"					=	"w tym tygodniu";		// this week
+"colloquial_n_0d"					=	"dzisiaj";			// this day
+"colloquial_n_0h"					=	"teraz";				// this hour
+"colloquial_n_0M"					=	"teraz";				// this minute
+"colloquial_n_0s"					=	"teraz";				// this second
+
+// RELEVANT TIME TO PRINT ALONG COLLOQUIAL STRING WHEN .includeRelevantTime = true
+"relevanttime_y"					=	"MMM yyyy";			// for colloquial year (=+-1) adds a time string like this:"(Feb 2016)"
+"relevanttime_yy"					=	"MMM yyyy";			// for colloquial years (>1) adds a time string like this:"(Feb 2016)"
+"relevanttime_m"					=	"MMM, dd yyyy";		// for colloquial month (=+-1) adds a time string like this:"(Feb 17, 2016)"
+"relevanttime_mm"					=	"MMM, dd yyyy";		// for colloquial months (>1) adds a time string like this: "(Feb 17, 2016)"
+"relevanttime_w"					=	"EEE, MMM dd";		// for colloquial months (>1) adds a time string like this: "(Wed Feb 17)"
+"relevanttime_ww"					=	"EEE, MMM dd";		// for colloquial months (>1) adds a time string like this: "(Wed Feb 17)"
+"relevanttime_d"					=	"EEE, MMM dd";		// for colloquial day (=+-1) adds a time string like this: "(Wed Feb 17)"
+"relevanttime_dd"					=	"EEE, MMM dd";		// for colloquial days (>1) adds a time string like this: "(Wed Feb 17)"
+"relevanttime_h"					=	"'o' HH:mm";			// for colloquial day (=+-1) adds a time string like this: "(At 13:20)"
+"relevanttime_hh"					=	"'o' HH:mm";			// for colloquial days (>1) adds a time string like this: "(At 13:20)"
+"relevanttime_M"					=	"";							// for colloquial minute(s) we have not any relevant time to print
+"relevanttime_MM"					=	"";							// for colloquial minute(s) we have not any relevant time to print
+"relevanttime_s"					=	"";							// for colloquial seconds(s) we have not any relevant time to print
+"relevanttime_ss"					=	"";							// for colloquial seconds(s) we have not any relevant time to print


### PR DESCRIPTION
I've added also `Localizable.stringsdict` file, because of specificity of Polish language. In some cases I recommend You to use `*.stringsdict` file instead of `*.strings`. You can find more at [https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html](url)