### PR TITLE
Swift 4 issue with `rangeAt` instead of `range(at`

### DIFF
--- a/Sources/SwiftDate/DOTNETDateTimeFormatter.swift
+++ b/Sources/SwiftDate/DOTNETDateTimeFormatter.swift
@@ -44,10 +44,10 @@ public class DOTNETDateTimeFormatter {
 				return nil
 			}
 			
-			guard let milliseconds = TimeInterval((string as NSString).substring(with: match.range(at: 1))) else { return nil }
+			guard let milliseconds = TimeInterval((string as NSString).substring(with: match.rangeAt(1))) else { return nil }
 			
 			// Parse timezone
-			let raw_tz = ((string as NSString).substring(with: match.range(at: 2)) as NSString)
+			let raw_tz = ((string as NSString).substring(with: match.rangeAt(2)) as NSString)
 			guard raw_tz.length > 1 else {
 				return nil
 			}


### PR DESCRIPTION
Saw it coming by in several forks, but isn't present in either 4.4.0 or 4.4.1 release. 
Would be nice to be able to compile this in Xcode 9/Swift 4.0 ;)