### PR TITLE
Use directly string, the characters property has been deprecated

### DIFF
--- a/Sources/SwiftDate/DOTNETDateTimeFormatter.swift
+++ b/Sources/SwiftDate/DOTNETDateTimeFormatter.swift
@@ -40,7 +40,7 @@ public class DOTNETDateTimeFormatter {
 	private static func parseDateString(_ string: String) -> (seconds: TimeInterval, tz: TimeZone)? {
 		do {
 			let parser = try NSRegularExpression(pattern: DOTNETDateTimeFormatter.pattern, options: .caseInsensitive)
-			guard let match = parser.firstMatch(in: string, options: .reportCompletion, range: NSRange(location: 0, length: string.characters.count)) else {
+			guard let match = parser.firstMatch(in: string, options: .reportCompletion, range: NSRange(location: 0, length: string.count)) else {
 				return nil
 			}
 			

--- a/Sources/SwiftDate/ISO8601Parser.swift
+++ b/Sources/SwiftDate/ISO8601Parser.swift
@@ -223,11 +223,11 @@ public class ISO8601Parser {
 	/// - Throws: throw an `ISO8601Error` if parsing operation fails
 	public init?(_ src: String, config: ISO8601Configuration = ISO8601Configuration()) {
 		let src_trimmed = src.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-		guard src_trimmed.characters.count > 0 else {
+		guard src_trimmed.count > 0 else {
 			return nil
 		}
 		self.string = src_trimmed.unicodeScalars
-		self.length = src_trimmed.characters.count
+		self.length = src_trimmed.count
 		self.cIdx = string.startIndex
 		self.eIdx = string.endIndex
 		self.cfg = config


### PR DESCRIPTION
The property `characters` was deprecated, Strings can be now directly used as a collection.

Documentation:
https://developer.apple.com/documentation/swift/string/1540072-characters