### PR TITLE
Fixed Italian, Spanish and Catalan localizations adding articles when needed

### DIFF
--- a/Sources/SwiftDate/SwiftDate.bundle/ca-ES.lproj/SwiftDate.strings
+++ b/Sources/SwiftDate/SwiftDate.bundle/ca-ES.lproj/SwiftDate.strings
@@ -1,17 +1,17 @@
 // COLLOQUIAL STRINGD
-"colloquial_f_y"					=	"pròxim any";		// year,future,singular:    "next year"
+"colloquial_f_y"					=	"l'any que ve";		// year,future,singular:    "next year"
 "colloquial_f_yy"					=	"el %d";			// year,future,plural:      "on 2016"
-"colloquial_p_y"					=	"passat any";		// year,past,singular:      "last year"
+"colloquial_p_y"					=	"l'any passat";		// year,past,singular:      "last year"
 "colloquial_p_yy"					=	"%d";				// year,past,plural:        "2015"
 
-"colloquial_f_m"					=	"pròxim mes";		// month,future,singular:	"next month"
+"colloquial_f_m"					=	"el mes que ve";	// month,future,singular:	"next month"
 "colloquial_f_mm"					=	"en %d mesos";		// month,future,plural:		"in 3 months"
-"colloquial_p_m"					=	"passat mes";		// month,past,singular:		"past month"
+"colloquial_p_m"					=	"el mes passat";	// month,past,singular:		"past month"
 "colloquial_p_mm"					=	"fa %d mesos";      // month,past,plural:		"3 months ago"
 
-"colloquial_f_w"					=	"propera setmana";		// week,future,singular:	"next week"
+"colloquial_f_w"					=	"la setmana que ve";	// week,future,singular:	"next week"
 "colloquial_f_ww"					=	"en %ld setmanes";		// week,future,plural:		"in 3 weeks"
-"colloquial_p_w"					=	"setmana passada";		// week,past,singular:		"past week"
+"colloquial_p_w"					=	"la setmana passada";	// week,past,singular:		"past week"
 "colloquial_p_ww"					=	"fa %d setmanes";		// week,past,plural:		"in 3 weeks"
 
 "colloquial_f_d"					=	"demà";             // day,future,singular:		"tomorrow"
@@ -31,8 +31,8 @@
 
 "colloquial_now"					=	"ara mateix";       // less than 5 minutes if .allowsNowOnColloquial is set
 
-"colloquial_n_0y"					=	"aquest anno";		// this year
-"colloquial_n_0m"					=	"aquest mese";		// this month
+"colloquial_n_0y"					=	"aquest any";		// this year
+"colloquial_n_0m"					=	"aquest mes";		// this month
 "colloquial_n_0w"					=	"aquesta setmana";	// this week
 "colloquial_n_0d"					=	"avui";				// this day
 "colloquial_n_0h"					=	"ara mateix";		// this hour

--- a/Sources/SwiftDate/SwiftDate.bundle/es-ES.lproj/SwiftDate.strings
+++ b/Sources/SwiftDate/SwiftDate.bundle/es-ES.lproj/SwiftDate.strings
@@ -1,22 +1,22 @@
 // COLLOQUIAL STRINGD
-"colloquial_f_y"					=	"próximo año";		// year,future,singular: 	"next year"
-"colloquial_f_yy"					=	"en %d";			// year,future,plural:		"on 2016"
-"colloquial_p_y"					=	"año pasado";		// year,past,singular:		"last year"
-"colloquial_p_yy"					=	"%d";				// year,past,plural:		"2015"
+"colloquial_f_y"					=	"el año que viene";		// year,future,singular: 	"next year"
+"colloquial_f_yy"					=	"en %d";			    // year,future,plural:		"on 2016"
+"colloquial_p_y"					=	"el año pasado";		// year,past,singular:		"last year"
+"colloquial_p_yy"					=	"%d";				    // year,past,plural:		"2015"
 
-"colloquial_f_m"					=	"próximo mes";		// month,future,singular:	"next month"
-"colloquial_f_mm"					=	"en %d meses";		// month,future,plural:		"in 3 months"
-"colloquial_p_m"					=	"mes pasado";		// month,past,singular:		"past month"
-"colloquial_p_mm"					=	"hace %d meses";	// month,past,plural:		"3 months ago"
+"colloquial_f_m"					=	"el mes que viene";		// month,future,singular:	"next month"
+"colloquial_f_mm"					=	"en %d meses";		    // month,future,plural:		"in 3 months"
+"colloquial_p_m"					=	"el mes pasado";		// month,past,singular:		"past month"
+"colloquial_p_mm"					=	"hace %d meses";	    // month,past,plural:		"3 months ago"
 
-"colloquial_f_w"					=	"próxima semana";		// week,future,singular:	"next week"
+"colloquial_f_w"					=	"la semana que viene";	// week,future,singular:	"next week"
 "colloquial_f_ww"					=	"en %ld semanas";		// week,future,plural:		"in 3 weeks"
-"colloquial_p_w"					=	"semana pasada";		// week,past,singular:		"past week"
+"colloquial_p_w"					=	"la semana pasada";		// week,past,singular:		"past week"
 "colloquial_p_ww"					=	"hace %d semanas";		// week,past,plural:		"in 3 weeks"
 
 "colloquial_f_d"					=	"mañana";			// day,future,singular:		"tomorrow"
 "colloquial_f_dd"					=	"en %d días";		// day,future,plural:		"in 3 days"
-"colloquial_p_d"					=	"ayer";		// day,past,singular:		"yesterday"
+"colloquial_p_d"					=	"ayer";		        // day,past,singular:		"yesterday"
 "colloquial_p_dd"					=	"hace %d días";		// day,past,plural:			"3 days ago"
 
 "colloquial_f_h"					=	"en una hora";		// hour,future,singular:	"in one hour"

--- a/Sources/SwiftDate/SwiftDate.bundle/it-IT.lproj/SwiftDate.strings
+++ b/Sources/SwiftDate/SwiftDate.bundle/it-IT.lproj/SwiftDate.strings
@@ -1,18 +1,18 @@
 // COLLOQUIAL STRINGD
-"colloquial_f_y"					=	"prossimo anno";		// year,future,singular: 	"next year"
+"colloquial_f_y"					=	"il prossimo anno";		// year,future,singular: 	"next year"
 "colloquial_f_yy"					=	"nel %d";				// year,future,plural:		"on 2016"
-"colloquial_p_y"					=	"anno scorso";			// year,past,singular:		"last year"
+"colloquial_p_y"					=	"l' anno scorso";		// year,past,singular:		"last year"
 "colloquial_p_yy"					=	"%d";					// year,past,plural:		"2015"
 
-"colloquial_f_m"					=	"prossimo mese";		// month,future,singular:	"next month"
+"colloquial_f_m"					=	"il prossimo mese";		// month,future,singular:	"next month"
 "colloquial_f_mm"					=	"tra %d mesi";			// month,future,plural:		"in 3 months"
-"colloquial_p_m"					=	"mese scorso";			// month,past,singular:		"past month"
+"colloquial_p_m"					=	"il mese scorso";	    // month,past,singular:		"past month"
 "colloquial_p_mm"					=	"%d mesi fa";			// month,past,plural:		"3 months ago"
 
-"colloquial_f_w"					=	"prossima settimana";	// week,future,singular:	"next week"
-"colloquial_f_ww"					=	"tra %d settimane";	// week,future,plural:		"in 3 weeks"
-"colloquial_p_w"					=	"settimana scorsa";		// week,past,singular:		"past week"
-"colloquial_p_ww"					=	"%d settimane fa";		// week,past,plural:		"in 3 weeks"
+"colloquial_f_w"					=	"la prossima settimana";    // week,future,singular:	"next week"
+"colloquial_f_ww"					=	"tra %d settimane";	        // week,future,plural:		"in 3 weeks"
+"colloquial_p_w"					=	"la settimana scorsa";		// week,past,singular:		"past week"
+"colloquial_p_ww"					=	"%d settimane fa";		    // week,past,plural:		"in 3 weeks"
 
 "colloquial_f_d"					=	"domani";			// day,future,singular:		"tomorrow"
 "colloquial_f_dd"					=	"tra %d giorni";	// day,future,plural:		"in 3 days"


### PR DESCRIPTION
We noticed an inconsistency in the translations, in latin languages most of the translations are literally translated from english but they don't produce the same meaning.
we fixed Italian (Me) Spanish and Catalan (@polqf) and confirmed that French is correct already.
The issue is that in these languages displaying "año pasado" doesn't sound as "last year" even if it is the literal translation, instead it should be "el año pasado".
Catalan also has some wrong translations (looks like influenced by italian 😬 )
Let us know what you think