### PR TITLE
Added Polish translation

### DIFF
--- a/Sources/SwiftDate/SwiftDate.bundle/pl.lproj/SwiftDate.strings
+++ b/Sources/SwiftDate/SwiftDate.bundle/pl.lproj/SwiftDate.strings
@@ -1,0 +1,62 @@
+// COLLOQUIAL STRINGD
+"colloquial_f_y"					=	"za rok";		        // year,future,singular: 	"next year"
+"colloquial_f_yy"					=	"w %d";			        // year,future,plural:		"on 2016"
+"colloquial_p_y"					=	"rok temu";		        // year,past,singular:		"last year"
+"colloquial_p_yy"					=	"w %d";				    // year,past,plural:		"2015"
+
+"colloquial_f_m"					=	"za miesiąc";		    // month,future,singular:	"next month"
+"colloquial_f_mm"					=	"za %d miesiące/-y";	// month,future,plural:		"in 3 months"
+"colloquial_p_m"					=	"miesiąc temu";		    // month,past,singular:		"past month"
+"colloquial_p_mm"					=	"%d miesiące/-y temu";	// month,past,plural:		"3 months ago"
+
+"colloquial_f_w"					=	"za tydzień";		    // week,future,singular:	"next week"
+"colloquial_f_ww"					=	"za %d tygodni(e)";		// week,future,plural:		"in 3 weeks"
+"colloquial_p_w"					=	"tydzień temu";		    // week,past,singular:		"past week"
+"colloquial_p_ww"					=	"%d tygodni(e) temu";	// week,past,plural:		"in 3 weeks"
+
+"colloquial_f_d"					=	"jutro";			    // day,future,singular:		"tomorrow"
+"colloquial_f_dd"					=	"za %d dni";		    // day,future,plural:		"in 3 days"
+"colloquial_p_d"					=	"wczoraj";		        // day,past,singular:		"yesterday"
+"colloquial_p_dd"					=	"%d dni temu";		    // day,past,plural:			"3 days ago"
+
+"colloquial_f_h"					=	"za godzinę";		    // hour,future,singular:	"in one hour"
+"colloquial_f_hh"					=	"za %d godzin(y)";		// hour,future,plural:		"in 3 hours"
+"colloquial_p_h"					=	"godzinę temu";		    // hour,past,singular:		"one hour ago"
+"colloquial_p_hh"					=	"%d godzin(y) temu";	// hour,past,plural:		"3 hours ago"
+
+"colloquial_f_M"					=	"za minutę";	        // minute,future,singular:	"in one minute"
+"colloquial_f_MM"					=	"za %d minut";	        // minute,future,plural:	"in 3 minutes"
+"colloquial_p_M"					=	"minutę temu";	        // minute,past,singular:	"one minute ago"
+"colloquial_p_MM"					=	"%d minut temu";	    // minute,past,plural:		"3 minutes ago"
+
+"colloquial_now"					=	"teraz";			    // less than 5 minutes if .allowsNowOnColloquial is set
+
+"colloquial_n_0y"					=	"w tym roku";		    // this year
+"colloquial_n_0m"					=	"w tym miesiącu";		// this month
+"colloquial_n_0w"					=	"w tym tygodniu";		// this week
+"colloquial_n_0d"					=	"dzisiaj";			    // this day
+"colloquial_n_0h"					=	"teraz";				// this hour
+"colloquial_n_0M"					=	"teraz";				// this minute
+"colloquial_n_0s"					=	"teraz";				// this second
+
+// RELEVANT TIME TO PRINT ALONG COLLOQUIAL STRING WHEN .includeRelevantTime = true
+"relevanttime_y"					=	"MMM yyyy";			    // for colloquial year (=+-1) adds a time string like this:"(Feb 2016)"
+"relevanttime_yy"					=	"MMM yyyy";			    // for colloquial years (>1) adds a time string like this:"(Feb 2016)"
+"relevanttime_m"					=	"MMM, dd yyyy";		    // for colloquial month (=+-1) adds a time string like this:"(Feb 17, 2016)"
+"relevanttime_mm"					=	"MMM, dd yyyy";		    // for colloquial months (>1) adds a time string like this: "(Feb 17, 2016)"
+"relevanttime_w"					=	"EEE, MMM dd";		    // for colloquial months (>1) adds a time string like this: "(Wed Feb 17)"
+"relevanttime_ww"					=	"EEE, MMM dd";		    // for colloquial months (>1) adds a time string like this: "(Wed Feb 17)"
+"relevanttime_d"					=	"EEE, MMM dd";		    // for colloquial day (=+-1) adds a time string like this: "(Wed Feb 17)"
+"relevanttime_dd"					=	"EEE, MMM dd";		    // for colloquial days (>1) adds a time string like this: "(Wed Feb 17)"
+"relevanttime_h"					=	"'o' HH:mm";			// for colloquial hour (=+-1) adds a time string like this: "(At 13:20)"
+"relevanttime_hh"					=	"'o' HH:mm";			// for colloquial hours (>1) adds a time string like this: "(At 13:20)"
+"relevanttime_M"					=	"";						// for colloquial minute(s) we have not any relevant time to print
+"relevanttime_MM"					=	"";						// for colloquial minute(s) we have not any relevant time to print
+"relevanttime_s"					=	"";						// for colloquial seconds(s) we have not any relevant time to print
+"relevanttime_ss"					=	"";						// for colloquial seconds(s) we have not any relevant time to print
+
+// Distant ranges for time unit
+"distant_h" 						= "HH:mm";
+"distant_d" 						= "MM/dd";
+"distant_m" 						= "MM/yyyy";
+"distant_y" 						= "yyyy";

--- a/SwiftDate.xcodeproj/project.pbxproj
+++ b/SwiftDate.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		646E53F21FB6335600939895 /* ColloquialDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646E53EE1FB6335600939895 /* ColloquialDateFormatter.swift */; };
 		DD7502881C68FEDE006590AF /* SwiftDate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6DA0F1BF000BD002C0205 /* SwiftDate.framework */; };
 		DD7502921C690C7A006590AF /* SwiftDate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D9F01BEFFFBE002C0205 /* SwiftDate.framework */; };
+		DF9D6F1C1FCC7F290096DB41 /* SwiftDate.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 375F8FF91F0ECD1C00ECC0FD /* SwiftDate.bundle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -654,6 +655,7 @@
 				375F8FDA1F0EC70C00ECC0FD /* LaunchScreen.storyboard in Resources */,
 				375F8FD71F0EC70C00ECC0FD /* Assets.xcassets in Resources */,
 				375F8FD51F0EC70C00ECC0FD /* Main.storyboard in Resources */,
+				DF9D6F1C1FCC7F290096DB41 /* SwiftDate.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
I've added polish translations.

There were few problems I had with this.

1. First of all in polish there is no single case for plural months and weeks.
For example for months:
"2,3,4 months ago" is "2,3,4 miesiące temu"
"5 months ago" is "5 miesięcy temu" (this is used for all other cases)

I've made it as "%d miesiące/-y temu" to handle all cases with this single variable.

2. Second of all I'm not sure why for `colloquial_p_yy` there is an exception comparing to all other cases like `colloquial_p_mm` and there is a year passed to this variable, instead of amount of years that passed. I would expect this to be:

`colloquial_p_yy` = "%d years ago"

Same question for future years.