### PR TITLE
Test fixes

### DIFF
--- a/Sources/SwiftDate/ISO8601Parser.swift
+++ b/Sources/SwiftDate/ISO8601Parser.swift
@@ -430,7 +430,7 @@ public class ISO8601Parser {
 		self.cfg.calendar.timeZone = tz
 		self.parsedDate = self.cfg.calendar.date(from: self.date_components!)
 
-		return (self.parsedDate,self.parsedTimeZone)
+		return (self.parsedDate, self.parsedTimeZone)
 	}
 	
 	

--- a/Sources/SwiftDate/Region.swift
+++ b/Sources/SwiftDate/Region.swift
@@ -72,6 +72,16 @@ public struct Region: CustomStringConvertible {
 		return Region(tz: tz, cal: cal, loc: loc)
 	}
 	
+	/// Generate a new region which uses `GMT` timezone and `Calendar` and `Locale` appropriate for reproducible tests
+	///
+	/// - returns: a new `Region`
+	public static func GMTForTests() -> Region {
+		let tz = TimeZoneName.gmt.timeZone
+		let cal = CalendarName.gregorian.calendar
+		let loc = LocaleName.english.locale
+		return Region(tz: tz, cal: cal, loc: loc)
+	}
+	
 	/// Generate a new regione which uses current device's local settings (`Calendar`,`TimeZone` and `Locale`)
 	///
 	/// - parameter auto: `true` to get automatically new settings when device's timezone/calendar/locale changes

--- a/Tests/SwiftDateTests/TestDateInRegion+Compare.swift
+++ b/Tests/SwiftDateTests/TestDateInRegion+Compare.swift
@@ -437,7 +437,7 @@ class TestDateInRegion_Compare: XCTestCase {
 
 		// #TEST 3:
 		// We want to see if a date is inside a given interval
-		let gmt = Region.GMT()
+		let gmt = Region.GMTForTests()
 		let format: DateFormat = .custom("yyyy-MM-dd HH:mm:ss")
 		// Create interval A
 		let interval_a_start = DateInRegion(string: "2012-04-05 12:00:00", format: format, fromRegion: gmt)!.absoluteDate

--- a/Tests/SwiftDateTests/TestDateInRegion+Components.swift
+++ b/Tests/SwiftDateTests/TestDateInRegion+Components.swift
@@ -109,7 +109,7 @@ class TestDateInRegion_Components: XCTestCase {
 		let romeRegion = Region(tz: TimeZoneName.europeRome, cal: CalendarName.gregorian, loc: LocaleName.current)
 		let romeDate = DateInRegion(components: [.year: 2000, .month: 1, .day: 1, .hour: 0, .minute: 0, .second: 0], fromRegion: romeRegion)!
 		
-		let gmtRegion = Region.GMT()
+		let gmtRegion = Region.GMTForTests()
 		let gmtDate = romeDate.toRegion(gmtRegion)
 		
 		XCTAssertEqual(gmtDate.year, 1999, "Failed get correct year")

--- a/Tests/SwiftDateTests/TestDateInRegion+Formatter.swift
+++ b/Tests/SwiftDateTests/TestDateInRegion+Formatter.swift
@@ -29,7 +29,7 @@ class TestDateInRegion_Formatter: XCTestCase {
 		let date = DateInRegion(
 			string: string,
 			format: .iso8601(options: .withInternetDateTimeExtended),
-			fromRegion: Region.GMT()
+			fromRegion: Region.GMTForTests()
 		)
 		let str = date!.string(format: .iso8601(options: .withInternetDateTimeExtended))
 		XCTAssertEqual(str, "2017-07-16T03:54:37.800Z", "Failed to keep correct milliseconds information from ISO8601 datetime")
@@ -150,7 +150,7 @@ class TestDateInRegion_Formatter: XCTestCase {
 		}
 		
 		let now = Date()
-		let now_cmp = Region.GMT().calendar.dateComponents([.year,.month,.day], from: now)
+		let now_cmp = Region.GMTForTests().calendar.dateComponents([.year,.month,.day], from: now)
 		validate("060224", expected: "2006-02-24T00:00:00Z")
 		validate("06-W22", expected: "2006-05-28T00:00:00Z")
 		validate("06-W2", expected: "2006-01-08T00:00:00Z")
@@ -242,8 +242,8 @@ class TestDateInRegion_Formatter: XCTestCase {
 	
 	func _executeDateTest(dateA: String, dateB: String, options: ColloquialDateFormatter.Options, expected: String) {
 		let dFormat = DateFormat.custom("dd-MM-yyyy HH:mm:ss")
-		let date_a = DateInRegion(string: dateA, format: dFormat, fromRegion: Region.GMT())!
-		let date_b = DateInRegion(string: dateB, format: dFormat, fromRegion: Region.GMT())!
+		let date_a = DateInRegion(string: dateA, format: dFormat, fromRegion: Region.GMTForTests())!
+		let date_b = DateInRegion(string: dateB, format: dFormat, fromRegion: Region.GMTForTests())!
 		let colloquial = date_a.colloquial(toDate: date_b, options: options)
 		print("colloquial= '\(colloquial!)', expected= '\(expected)'")
 		XCTAssert(colloquial == expected, "Failed to get colloquial for dates: \(dateA) - \(dateB). Got '\(colloquial ?? "<nil>")', expected '\(expected)'")

--- a/Tests/SwiftDateTests/TestDateInRegion.swift
+++ b/Tests/SwiftDateTests/TestDateInRegion.swift
@@ -65,7 +65,7 @@ class DateInRegionTest: XCTestCase {
 	
 	func testDateInRegionInit_StringCustom() {
 		let customString = "090911"
-		guard let dateInUTC = DateInRegion(string: customString, format: .custom("ddMMyy"), fromRegion: Region.GMT()) else {
+		guard let dateInUTC = DateInRegion(string: customString, format: .custom("ddMMyy"), fromRegion: Region.GMTForTests()) else {
 			XCTAssert(false, "Failed to create a region from custom string format")
 			return
 		}
@@ -75,7 +75,7 @@ class DateInRegionTest: XCTestCase {
 	
 	func testDateInRegionInit_AltRSSWithZ() {
 		let customString = "09 Sep 2011 15:26:08 Z"
-		guard let dateInUTC = DateInRegion(string: customString, format: .rss(alt: true), fromRegion: Region.GMT()) else {
+		guard let dateInUTC = DateInRegion(string: customString, format: .rss(alt: true), fromRegion: Region.GMTForTests()) else {
 			XCTAssert(false, "Failed to create a region from Alt RSS format")
 			return
 		}
@@ -85,7 +85,7 @@ class DateInRegionTest: XCTestCase {
 	
 	func testDateInRegionInit_AltRSSWithTimezone() {
 		let customString = "09 Sep 2011 15:26:08 -0400"
-		guard let dateInUTC = DateInRegion(string: customString, format: .rss(alt: true), fromRegion: Region.GMT()) else {
+		guard let dateInUTC = DateInRegion(string: customString, format: .rss(alt: true), fromRegion: Region.GMTForTests()) else {
 			XCTAssert(false, "Failed to create a region from Alt RSS format")
 			return
 		}
@@ -96,7 +96,7 @@ class DateInRegionTest: XCTestCase {
 	
 	func testDateInRegionInit_FromRSSWithZ() {
 		let customString = "Fri, 09 Sep 2011 15:26:08 Z"
-		guard let dateInUTC = DateInRegion(string: customString, format: .rss(alt: false), fromRegion: Region.GMT()) else {
+		guard let dateInUTC = DateInRegion(string: customString, format: .rss(alt: false), fromRegion: Region.GMTForTests()) else {
 			XCTAssert(false, "Failed to create a region from RSS format")
 			return
 		}
@@ -106,7 +106,7 @@ class DateInRegionTest: XCTestCase {
 	
 	func testDateInRegionInit_FromRSSWithTimezone() {
 		let customString = "Fri, 09 Sep 2011 15:26:08 +0200"
-		guard let dateInUTC = DateInRegion(string: customString, format: .rss(alt: false), fromRegion: Region.GMT()) else {
+		guard let dateInUTC = DateInRegion(string: customString, format: .rss(alt: false), fromRegion: Region.GMTForTests()) else {
 			XCTAssert(false, "Failed to create a region from RSS format")
 			return
 		}
@@ -116,7 +116,7 @@ class DateInRegionTest: XCTestCase {
 	
 	func testDateInRegionInit_FromExtended() {
 		let customString = "Fri 09-Sep-2011 AD 15:26:08.123 +0100"
-		guard let dateInUTC = DateInRegion(string: customString, format: .extended, fromRegion: Region.GMT()) else {
+		guard let dateInUTC = DateInRegion(string: customString, format: .extended, fromRegion: Region.GMTForTests()) else {
 			XCTAssert(false, "Failed to create a region from extended format")
 			return
 		}
@@ -126,7 +126,7 @@ class DateInRegionTest: XCTestCase {
 	
 	func testDateInRegion_ISO8601_NoZ() {
 		let customString = "2015-01-05T22:10:55+0200"
-		guard let dateInUTC = DateInRegion(string: customString, format: .iso8601(options: .withInternetDateTime), fromRegion: Region.GMT()) else {
+		guard let dateInUTC = DateInRegion(string: customString, format: .iso8601(options: .withInternetDateTime), fromRegion: Region.GMTForTests()) else {
 			XCTAssert(false, "Failed to create a region from ISO8601 format")
 			return
 		}
@@ -136,7 +136,7 @@ class DateInRegionTest: XCTestCase {
 	
 	func testDateInRegion_ISO8601InternetDateTimesExtendedWithZ() {
 		let customString = "2016-09-05T04:38:04.746Z"
-		guard let dateInUTC = DateInRegion(string: customString, format: .iso8601(options: .withInternetDateTimeExtended), fromRegion: Region.GMT()) else {
+		guard let dateInUTC = DateInRegion(string: customString, format: .iso8601(options: .withInternetDateTimeExtended), fromRegion: Region.GMTForTests()) else {
 			XCTAssert(false, "Failed to create a region from ISO8601 internet date times extended format")
 			return
 		}
@@ -146,7 +146,7 @@ class DateInRegionTest: XCTestCase {
 	
 	func testDateInRegion_ISO8601InternetDateTimesExtendedWithTimezone() {
 		let customString = "2016-09-05T04:38:04.746+0200"
-		guard let dateInUTC = DateInRegion(string: customString, format: .iso8601(options: .withInternetDateTimeExtended), fromRegion: Region.GMT()) else {
+		guard let dateInUTC = DateInRegion(string: customString, format: .iso8601(options: .withInternetDateTimeExtended), fromRegion: Region.GMTForTests()) else {
 			XCTAssert(false, "Failed to create a region from ISO8601 internet date times extended format")
 			return
 		}


### PR DESCRIPTION
This fixes some of the failing XCTests when they are run in an environment with default German locale and calendar. 

I was not yet able to fix four tests that are still failing in such an environment:

```
		validate("-W2", expected: now.string(format: .custom("yyyy")) + "-01-08T00:00:00Z")
		validate("-W2-2", expected: now.string(format: .custom("yyyy")) + "-01-10T00:00:00Z")
		validate("-W-3", expected: now.string(format: .custom("yyyy")) + "-01-04T00:00:00Z")
		validate("--W-3", expected: now.string(format: .custom("yyyy")) + "-01-04T00:00:00Z")
```

I think they fail, because a week here starts on Mondays instead of Sundays. I could not track down the exact location of the problem though.