### PR TITLE
Fixes for Traditional Chinese translation

### DIFF
--- a/Sources/SwiftDate/SwiftDate.bundle/zh-Hant-CN.lproj/SwiftDate.strings
+++ b/Sources/SwiftDate/SwiftDate.bundle/zh-Hant-CN.lproj/SwiftDate.strings
@@ -32,8 +32,8 @@
 "colloquial_now"                    =   "剛剛";           // less than 5 minutes if .allowsNowOnColloquial is set
 
 "colloquial_n_0y"					=	"今年";			// this year
-"colloquial_n_0m"					=	"这个月";			// this month
-"colloquial_n_0w"					=	"本星期";			// this week
+"colloquial_n_0m"					=	"本月";			// this month
+"colloquial_n_0w"					=	"本週";			// this week
 "colloquial_n_0d"					=	"今天";			// this day
 "colloquial_n_0h"					=	"剛剛";			// this hour
 "colloquial_n_0M"					=	"剛剛";			// this minute


### PR DESCRIPTION
One of the fixed is Simplified Chinese, not Traditional Chinese.
And another one is not general using.