### PR TITLE
Fixed test integration with TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,24 @@
-# .travis.yml
-
-# references:
-# * http://www.objc.io/issue-6/travis-ci.html
-# * https://github.com/supermarin/xcpretty#usage
-
-osx_image: xcode7.3
 language: objective-c
-xcode_sdk: macosx10.11
-xcode_scheme: SwiftDateTests-OSX
-before_install:
-- export LANG=en_US.UTF-8
-- env
-- locale
-- brew update
-- brew upgrade carthage 
-- brew install swiftlint
-- carthage update --project-directory XCode --platform osx
-after_success:
-- swiftlint lint --path Sources/SwiftDate
-- pod lib lint
+osx_image: xcode9.3
+
+env:
+  global:
+  - LC_CTYPE=en_US.UTF-8
+  - LANG=en_US.UTF-8
+  - PROJECT=SwiftDate.xcodeproj
+  - IOS_FRAMEWORK_SCHEME="SwiftDate-iOS"
+  - MACOS_FRAMEWORK_SCHEME="SwiftDate-macOS"
+  - TVOS_FRAMEWORK_SCHEME="SwiftDate-tvOS"
+  - WATCHOS_FRAMEWORK_SCHEME="SwiftDate-watchOS"
+  matrix:
+    - DESTINATION="OS=11.3,name=iPhone X"          SCHEME="$IOS_FRAMEWORK_SCHEME"
+    - DESTINATION="OS=11.3,name=Apple TV 4K"       SCHEME="$TVOS_FRAMEWORK_SCHEME"
+    - DESTINATION="arch=x86_64"                    SCHEME="$MACOS_FRAMEWORK_SCHEME"
+
+script:
+  # Ensures that the return code from xcodebuild is passed along to xcpretty
+  - set -o pipefail
+  
+  # Runs the tests in Debug and Release configurations | xcpretty
+  - xcodebuild -project "$PROJECT" -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty
+  - xcodebuild -project "$PROJECT" -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty


### PR DESCRIPTION
Rewrote the .travis.yml based on the Alamofire project. It will now run the unit tests on iOS, macOS and tvOS using Xcode 9.3.

Currently there are 4 tests which are failing, but I believe those are out of the scope for this pull request in order to keep its purpose clear.