### PR TITLE
Added ordinalDay to Date+Components and DateInRegion+Components

### DIFF
--- a/Sources/SwiftDate/Date+Components.swift
+++ b/Sources/SwiftDate/Date+Components.swift
@@ -58,6 +58,11 @@ public extension Date {
 	public var day: Int {
 		return self.inDateDefaultRegion().day
 	}
+    
+    /// The number of day in ordinal style format for the receiver expressed in the context of `defaultRegion`.
+    public var ordinalDay: String {
+        return self.inDateDefaultRegion().ordinalDay
+    }
 	
 	/// The number of hour units for the receiver expressed in the context of `defaultRegion`.
 	public var hour: Int {

--- a/Sources/SwiftDate/DateInRegion+Components.swift
+++ b/Sources/SwiftDate/DateInRegion+Components.swift
@@ -60,6 +60,15 @@ extension DateInRegion {
 	public var day: Int {
 		return self.value(forComponent: .day)
 	}
+    
+    /// The number of day in ordinal style format for the receiver in current locale.
+    /// For example, in the en_US locale, the number 3 is represented as 3rd;
+    /// in the fr_FR locale, the number 3 is represented as 3e.
+    /// - note: This value is interpreted in the context of the locale with which it is used
+    public var ordinalDay: String {
+        let day = self.value(forComponent: .day)
+        return self.formatters.ordinalNumberFormatter().string(from: day as NSNumber) ?? "\(day)"
+    }
 	
 	/// The number of hour units for the receiver.
 	/// - note: This value is interpreted in the context of the calendar and timezone with which it is used

--- a/Sources/SwiftDate/DateInRegion.swift
+++ b/Sources/SwiftDate/DateInRegion.swift
@@ -34,6 +34,9 @@ public class DateInRegion: CustomStringConvertible {
 		
 		/// `DateIntervalFormatter` reserved instance (nil unless you set `.useSharedFormatters = false`)
 		private var customDateIntervalFormatter: DateIntervalFormatter? = nil
+        
+        /// `NumberFormatter` reserved instance (nil unless you set `.useSharedFormatters = false`)
+        private var customOrdinalNumberFormatter: NumberFormatter? = nil
 
 		/// If true this instance of `DateInRegion` will use formatters shared along calling thread.
 		/// If false a new date formatter is created automatically and used only by a single `DateInRegion`
@@ -117,6 +120,30 @@ public class DateInRegion: CustomStringConvertible {
 			formatter!.locale = self.locale
 			return formatter!
 		}
+        
+        /// Return an `NumberFormatter` instance. Returned instance is the one shared along calling thread
+        /// if `.useSharedFormatters = false`; otherwise a reserved instance is created for this `DateInRegion`
+        ///
+        /// - returns: a new instance of the formatter
+        public  func ordinalNumberFormatter() -> NumberFormatter {
+            var formatter: NumberFormatter? = nil
+            if useSharedFormatters == true {
+                let name = "SwiftDate_\(NSStringFromClass(NumberFormatter.self))"
+                formatter = localThreadSingleton(key: name, create: { () -> NumberFormatter in
+                    return NumberFormatter()
+                })
+            } else {
+                if customOrdinalNumberFormatter == nil {
+                    customOrdinalNumberFormatter = NumberFormatter()
+                    formatter = customOrdinalNumberFormatter
+                }
+            }
+            if #available(iOSApplicationExtension 9.0, *) {
+                formatter!.numberStyle = .ordinal
+            }
+            formatter!.locale = self.locale
+            return formatter!
+        }
 	}
 	
 	/// Initialize a new `DateInRegion` object from an absolute date and a destination region.

--- a/Tests/SwiftDateTests/TestDateInRegion+Components.swift
+++ b/Tests/SwiftDateTests/TestDateInRegion+Components.swift
@@ -182,6 +182,20 @@ class TestDateInRegion_Components: XCTestCase {
 		let localDate = DateInRegion(components: [.year: 2020, .month: 02], fromRegion: rome)!
 		XCTAssert(localDate.monthDays == 29,"Failed to get the correct value of the monthDays for a leap year")
 	}
+    
+    func test_ordinalDay() {
+        let localDate = DateInRegion(components: [.year: 2002, .month: 3, .day: 1, .hour: 5, .minute: 30], fromRegion: newYork)!
+        XCTAssert(localDate.ordinalDay == "1st", "Failed to get the correct value of the ordinalDay for a date")
+        
+        let localDate2 = DateInRegion(components: [.year: 2002, .month: 3, .day: 2, .hour: 5, .minute: 30], fromRegion: newYork)!
+        XCTAssert(localDate2.ordinalDay == "2nd", "Failed to get the correct value of the ordinalDay for a date")
+        
+        let localDate3 = DateInRegion(components: [.year: 2002, .month: 3, .day: 3, .hour: 5, .minute: 30], fromRegion: newYork)!
+        XCTAssert(localDate3.ordinalDay == "3rd", "Failed to get the correct value of the ordinalDay for a date")
+        
+        let localDate4 = DateInRegion(components: [.year: 2002, .month: 3, .day: 4, .hour: 5, .minute: 30], fromRegion: newYork)!
+        XCTAssert(localDate4.ordinalDay == "4th", "Failed to get the correct value of the ordinalDay for a date")
+    }
 	
 	func test_nearestHour() {
 		let localDate = DateInRegion(components: [.year: 2020, .month: 02, .day: 14, .hour: 13, .minute: 15], fromRegion: rome)!


### PR DESCRIPTION
It returns the number of day in ordinal format. This is useful for writing dates in formats like May 4th.
