### PR TITLE
fix ISOParser counting hyphens logic

### DIFF
--- a/Sources/SwiftDate/Formatters/ISOParser.swift
+++ b/Sources/SwiftDate/Formatters/ISOParser.swift
@@ -211,7 +211,7 @@ public class ISOParser: StringToDateTransformable {
 
 		var idx = self.cIdx
 		while idx < self.eIdx {
-			if string[idx] == "-" { hyphens += 1 } else { break }
+			if string[idx] == "-" { hyphens += 1 } else { continue }
 			idx = string.index(after: idx)
 		}
 


### PR DESCRIPTION
testTZInISOParser() is crashed using XCode10 beta5 because ISOParser won't count hyphens correctly.

<img width="1299" alt="2018-08-10 15 52 05" src="https://user-images.githubusercontent.com/211816/43943264-e0ec6450-9cb5-11e8-89d9-76273bd0587c.png">
