### PR TITLE
Fix DateInRegion(milliseconds:) to work with actual milliseconds

### DIFF
--- a/Sources/SwiftDate/DateInRegion/DateInRegion.swift
+++ b/Sources/SwiftDate/DateInRegion/DateInRegion.swift
@@ -103,7 +103,7 @@ public struct DateInRegion: DateRepresentable, Decodable, Encodable, CustomStrin
 	///   - interval: seconds since the Unix Epoch timestamp.
 	///   - region: region in which the date must be expressed, `nil` uses the default region at UTC timezone
 	public init(milliseconds interval: Int, region: Region = Region.UTC) {
-		self.date = Date(timeIntervalSince1970: TimeInterval(interval / 1000))
+		self.date = Date(timeIntervalSince1970: TimeInterval(interval) / 1000)
 		self.region = region
 	}
 

--- a/Tests/SwiftDateTests/TestDateInRegion.swift
+++ b/Tests/SwiftDateTests/TestDateInRegion.swift
@@ -73,6 +73,10 @@ class TestDateInRegion: XCTestCase {
 		XCTAssert( (msecsFromEpochInRegion.date.timeIntervalSince1970 == 5), "Failed to create DateInRegion from epoch time and fixed region / different date")
 		XCTAssert( (msecsFromEpochInRegion.region == regionBerlin), "Failed to create DateInRegion from epoch time and fixed region / different date")
 
+		// Init with fraction of seconds
+		let msecsLessThanSeconds = DateInRegion(milliseconds: 10)
+		XCTAssertEqual(round(msecsLessThanSeconds.date.timeIntervalSince1970 * 1000), 10)
+
 	}
 
 	func testDateInRegion_InitFromComponents() {


### PR DESCRIPTION
The previous code was just truncating it to seconds.