### PR TITLE
Fix subtract operation between DateInRegion objects

### DIFF
--- a/Sources/SwiftDate/DateInRegion/DateInRegion+Math.swift
+++ b/Sources/SwiftDate/DateInRegion/DateInRegion+Math.swift
@@ -11,7 +11,7 @@ import Foundation
 // MARK: - Math Operation DateInRegion - DateInRegion
 
 public func - (lhs: DateInRegion, rhs: DateInRegion) -> TimeInterval {
-	return rhs.timeIntervalSince(lhs)
+	return lhs.timeIntervalSince(rhs)
 }
 
 // MARK: - Math Operation DateInRegion - Date Components


### PR DESCRIPTION
If `lhs` date is later than `rhs` one, returned time interval should be positive.