### PR TITLE
Fixes an issue where 'orEqual' parameter was not passed to inDefaultRegion.isInRange

### DIFF
--- a/Sources/SwiftDate/Date/Date+Compare.swift
+++ b/Sources/SwiftDate/Date/Date+Compare.swift
@@ -75,9 +75,9 @@ public extension Date {
 	///   - granularity: smallest unit that must, along with all larger units, be greater for the given dates.
 	/// - Returns: Boolean
 	public func isInRange(date startDate: Date, and endDate: Date, orEqual: Bool = false, granularity: Calendar.Component = .nanosecond) -> Bool {
-		return self.inDefaultRegion().isInRange(date: startDate.inDefaultRegion(), and: endDate.inDefaultRegion(), granularity: granularity)
+        return self.inDefaultRegion().isInRange(date: startDate.inDefaultRegion(), and: endDate.inDefaultRegion(), orEqual: orEqual, granularity: granularity)
 	}
-	
+
 	/// Compares equality of two given dates based on their components down to a given unit
 	/// granularity.
 	///


### PR DESCRIPTION
The parameter `orEqual` is not working for the `isInRange` function because its not being passed to the `inDefaultRegion.isInRange` function.