### PR TITLE
RoundingStrategy for RelativeFormatter.Gradation.Rule

### DIFF
--- a/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatter+Style.swift
+++ b/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatter+Style.swift
@@ -142,7 +142,25 @@ public extension RelativeFormatter {
 					}
 				}
 
-			}
+            }
+
+            public enum RoundingStrategy {
+
+                case regularRound
+                case ceiling
+                case flooring
+                case custom((Double) -> Double)
+
+                func round(_ value: Double) -> Double {
+
+                    switch self {
+                    case .regularRound:                 return Darwin.round(value)
+                    case .ceiling:                      return ceil(value)
+                    case .flooring:                     return floor(value)
+                    case .custom(let roundingFunction): return roundingFunction(value)
+                    }
+                }
+            }
 
 			/// The time unit to which the rule refers.
 			/// It's used to evaluate the factor.
@@ -155,6 +173,9 @@ public extension RelativeFormatter {
 
 			/// Granuality threshold of the unit
 			public var granularity: Double?
+
+            /// The rounding strategy that should be used prior to generating the relative time
+            public var roundingStrategy: RoundingStrategy
 
 			/// Relation with a previous threshold
 			public var thresholdPrevious: [Unit: Double]?
@@ -173,11 +194,16 @@ public extension RelativeFormatter {
 			///   - granularity: granularity value.
 			///   - prev: relation with a previous rule in gradation lsit.
 			///   - formatter: custom formatter.
-			public init(_ unit: Unit, threshold: ThresholdType?,
-						granularity: Double? = nil, prev: [Unit: Double]? = nil, formatter: CustomFormatter? = nil ) {
+			public init(_ unit: Unit,
+                        threshold: ThresholdType?,
+						granularity: Double? = nil,
+                        roundingStrategy: RoundingStrategy = .regularRound,
+                        prev: [Unit: Double]? = nil,
+                        formatter: CustomFormatter? = nil ) {
 				self.unit = unit
 				self.threshold = threshold
 				self.granularity = granularity
+                self.roundingStrategy = roundingStrategy
 				self.thresholdPrevious = prev
 				self.customFormatter = formatter
 			}

--- a/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatter.swift
+++ b/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatter.swift
@@ -238,7 +238,7 @@ public class RelativeFormatter: DateToStringTrasformable {
 			amount = round(amount / granularity) * granularity
 		}
 
-		let value: Double = -1.0 * Double(elapsed.sign) * round(amount)
+		let value: Double = -1.0 * Double(elapsed.sign) * suitableRule.roundingStrategy.round(amount)
 		let formatString = relativeFormat(locale: locale, flavour: flavour, value: value, unit: suitableRule.unit)
 		return formatString.replacingOccurrences(of: "{0}", with: String(Int(abs(value))))
 	}

--- a/SwiftDate.podspec
+++ b/SwiftDate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftDate"
-  s.version      = "5.1.0"
+  s.version      = "5.2.0"
   s.summary      = "The best way to deal with Dates & Time Zones in Swift"
   s.homepage     = "https://github.com/malcommac/SwiftDate.git"
   s.license      = { :type => "MIT", :file => "LICENSE" }
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.10"
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
-  s.source       = { :git => "https://github.com/malcommac/SwiftDate.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/rkreutz-teamwork/SwiftDate.git", :tag => s.version.to_s }
   s.source_files  = "Sources/**/*"
   s.frameworks  = "Foundation"
   s.swift_version = "4.2"


### PR DESCRIPTION
Adding the RoundingStrategy to RelativeFormatter.Gradation.Rule, so we can specify how a given value will be rounded to generate the relative time string. 

This issue emerged at a very specific case, where I'd like to apply a different rounding function to the values prior to the relative time string being generated. Using `Darwin.round` is just fine for most cases, but in this specific case I had to `Darwin.ceil` the value, so I've added made an enum which you can specify either `Darwin.round`, `Darwin.ceil`, `Darwin.floor` or a custom function.