### PR TITLE
httpheader formatter is not correct 

### DIFF
--- a/Sources/SwiftDate/Formatters/Formatter+Protocols.swift
+++ b/Sources/SwiftDate/Formatters/Formatter+Protocols.swift
@@ -88,7 +88,7 @@ public enum DateToStringStyles {
 /// - rss: The RSS formatted date "EEE, d MMM yyyy HH:mm:ss ZZZ" i.e. "Fri, 09 Sep 2011 15:26:08 +0200"
 /// - altRSS: The Alternative RSS formatted date "d MMM yyyy HH:mm:ss ZZZ" i.e. "09 Sep 2011 15:26:08 +0200"
 /// - dotNet: The dotNet formatted date "/Date(%d%d)/" i.e. "/Date(1268123281843)/"
-/// - httpHeader: The http header formatted date "EEE, dd MM yyyy HH:mm:ss ZZZ" i.e. "Tue, 15 Nov 1994 12:45:26 GMT"
+/// - httpHeader: The http header formatted date "EEE, dd MM yyyy HH:mm:ss zzz" i.e. "Tue, 15 Nov 1994 12:45:26 GMT"
 /// - strict: custom string format with lenient options active
 /// - custom: custom string format
 /// - standard: A generic standard format date i.e. "EEE MMM dd HH:mm:ss Z yyyy"

--- a/Sources/SwiftDate/Formatters/Formatter+Protocols.swift
+++ b/Sources/SwiftDate/Formatters/Formatter+Protocols.swift
@@ -25,7 +25,7 @@ public protocol StringToDateTransformable {
 /// - rss: The RSS formatted date "EEE, d MMM yyyy HH:mm:ss ZZZ" i.e. "Fri, 09 Sep 2011 15:26:08 +0200"
 /// - altRSS: The Alternative RSS formatted date "d MMM yyyy HH:mm:ss ZZZ" i.e. "09 Sep 2011 15:26:08 +0200"
 /// - dotNet: The dotNet formatted date "/Date(%d%d)/" i.e. "/Date(1268123281843)/"
-/// - httpHeader: The http header formatted date "EEE, dd MM yyyy HH:mm:ss ZZZ" i.e. "Tue, 15 Nov 1994 12:45:26 GMT"
+/// - httpHeader: The http header formatted date "EEE, dd MM yyyy HH:mm:ss zzz" i.e. "Tue, 15 Nov 1994 12:45:26 GMT"
 /// - custom: custom string format
 /// - standard: A generic standard format date i.e. "EEE MMM dd HH:mm:ss Z yyyy"
 /// - date: Date only format (short = "2/27/17", medium = "Feb 27, 2017", long = "February 27, 2017", full = "Monday, February 27, 2017"

--- a/Sources/SwiftDate/Supports/Commons.swift
+++ b/Sources/SwiftDate/Supports/Commons.swift
@@ -125,8 +125,8 @@ public struct DateFormats {
 	/// The RSS formatted date "EEE, d MMM yyyy HH:mm:ss ZZZ" i.e. "Fri, 09 Sep 2011 15:26:08 +0200"
 	public static let rss: String = "EEE, d MMM yyyy HH:mm:ss ZZZ"
 
-	/// The http header formatted date "EEE, dd MM yyyy HH:mm:ss ZZZ" i.e. "Tue, 15 Nov 1994 12:45:26 GMT"
-	public static let httpHeader: String = "EEE, dd MM yyyy HH:mm:ss ZZZ"
+	/// The http header formatted date "EEE, dd MM yyyy HH:mm:ss zzz" i.e. "Tue, 15 Nov 1994 12:45:26 GMT"
+	public static let httpHeader: String = "EEE, dd MM yyyy HH:mm:ss zzz"
 
 	/// A generic standard format date i.e. "EEE MMM dd HH:mm:ss Z yyyy"
 	public static let standard: String = "EEE MMM dd HH:mm:ss Z yyyy"


### PR DESCRIPTION
According to [Unicode Technical Reference #35.](http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns)
ZZZ represents "The ISO8601 basic format with hours, minutes and optional seconds fields." like +0000 while zzz represents "The short specific non-location format." like GMT 
