### PR TITLE
Relative Formatting: Use available relative values for a unit

### DIFF
--- a/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatter.swift
+++ b/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatter.swift
@@ -257,10 +257,29 @@ public class RelativeFormatter: DateToStringTrasformable {
 			return ""
 		}
 
-		// Choose either "past" or "future" based on time `value` sign.
-		// If "past" is same as "future" then they're stored as "other".
-		// If there's only "other" then it's being collapsed.
-		let quantifierKey = (value <= 0 ? "past" : "future")
+    // Choose either "previous", "past", "current", "next" or "future" based on time `value` sign.
+    // If "next" is not present, we fallback on "future"
+    // If "previous" is not present, we fallback on "past"
+    // If "current" is not present, we fallback on "past"
+    // If "past" is same as "future" then they're stored as "other".
+    // If there's only "other" then it's being collapsed.
+    let quantifierKey: String
+
+    switch value {
+    case -1 where unitRules["previous"] != nil: // If it is previous value -1, and previous unitRule exist
+      quantifierKey = "previous"
+    case 0 where unitRules["current"] != nil: // If it is current value 0, and current unitRule exist
+      quantifierKey = "current"
+    case ...0: // If value is up to 0 included, also fallback when current or previous isn't found
+      quantifierKey = "past"
+    case 1 where unitRules["next"] != nil: // If it is next value 1, and next unitRule exist
+      quantifierKey = "next"
+    case 1...: // If it is future value >0, and fallback if next isn't found
+      quantifierKey = "future"
+    default: // Should never happen
+      fatalError()
+    }
+    
 		if let fixedValue = unitRules[quantifierKey] as? String {
 			return fixedValue
 		} else if let quantifierRules = unitRules[quantifierKey] as? [String: Any] {


### PR DESCRIPTION
Currently, when you use relative formatting, only the "past" and "future" values are used.  
This PR allow us to use other values such as "current", "previous" and "next" if they are available.