### PR TITLE
earlierDate and laterDate optimisation

### DIFF
--- a/Sources/SwiftDate/Date/Date+Compare.swift
+++ b/Sources/SwiftDate/Date/Date+Compare.swift
@@ -101,7 +101,7 @@ public extension Date {
 	/// - Parameter date: The date to compare to self
 	/// - Returns: The date that is earlier
 	func earlierDate(_ date: Date) -> Date {
-		return (timeIntervalSince1970 <= date.timeIntervalSince1970) ? self : date
+		return timeIntervalSince(date) <= 0 ? self : date
 	}
 
 	/// Return the later of two dates, between self and a given date.
@@ -109,7 +109,7 @@ public extension Date {
 	/// - Parameter date: The date to compare to self
 	/// - Returns: The date that is later
 	func laterDate(_ date: Date) -> Date {
-		return (timeIntervalSince1970 >= date.timeIntervalSince1970) ? self : date
+		return timeIntervalSince(date) >= 0 ? self : date
 	}
 
 }

--- a/Sources/SwiftDate/DateInRegion/DateInRegion+Compare.swift
+++ b/Sources/SwiftDate/DateInRegion/DateInRegion+Compare.swift
@@ -299,7 +299,7 @@ public extension DateInRegion {
 	/// - Parameter date: The date to compare to self
 	/// - Returns: The date that is earlier
 	func earlierDate(_ date: DateInRegion) -> DateInRegion {
-		return (self.date.timeIntervalSince1970 <= date.date.timeIntervalSince1970) ? self : date
+		return self.date.timeIntervalSince(date.date) <= 0 ? self : date
 	}
 
 	/// Return the later of two dates, between self and a given date.
@@ -307,7 +307,7 @@ public extension DateInRegion {
 	/// - Parameter date: The date to compare to self
 	/// - Returns: The date that is later
 	func laterDate(_ date: DateInRegion) -> DateInRegion {
-		return (self.date.timeIntervalSince1970 >= date.date.timeIntervalSince1970) ? self : date
+		return self.date.timeIntervalSince(date.date) >= 0 ? self : date
 	}
 
 }

--- a/Tests/SwiftDateTests/TestDateInRegion+Compare.swift
+++ b/Tests/SwiftDateTests/TestDateInRegion+Compare.swift
@@ -260,10 +260,14 @@ class TestDateInRegion_Compare: XCTestCase {
 		// earlierDate()
 		XCTAssert( (date1.earlierDate(date2) == date1), "Failed to get .earlierDate()")
 		XCTAssert( (date1.earlierDate(date3) == date1), "Failed to get .earlierDate()")
-
+                XCTAssert( (date1.date.earlierDate(date2.date) == date1.date), "Failed to get .earlierDate()")
+                XCTAssert( (date1.date.earlierDate(date3.date) == date1.date), "Failed to get .earlierDate()")
+		
 		// laterDate()
 		XCTAssert( (date1.laterDate(date2) == date2), "Failed to get .laterDate()")
 		XCTAssert( (date1.laterDate(date3) == date3), "Failed to get .laterDate()")
+                XCTAssert( (date1.date.laterDate(date2.date) == date2.date), "Failed to get .laterDate()")
+                XCTAssert( (date1.date.laterDate(date3.date) == date3.date), "Failed to get .laterDate()")
 	}
 
 	func testDateInRegion_compareMath() {

--- a/Tests/SwiftDateTests/TestDateInRegion+Compare.swift
+++ b/Tests/SwiftDateTests/TestDateInRegion+Compare.swift
@@ -260,14 +260,14 @@ class TestDateInRegion_Compare: XCTestCase {
 		// earlierDate()
 		XCTAssert( (date1.earlierDate(date2) == date1), "Failed to get .earlierDate()")
 		XCTAssert( (date1.earlierDate(date3) == date1), "Failed to get .earlierDate()")
-                XCTAssert( (date1.date.earlierDate(date2.date) == date1.date), "Failed to get .earlierDate()")
-                XCTAssert( (date1.date.earlierDate(date3.date) == date1.date), "Failed to get .earlierDate()")
+		XCTAssert( (date1.date.earlierDate(date2.date) == date1.date), "Failed to get .earlierDate()")
+		XCTAssert( (date1.date.earlierDate(date3.date) == date1.date), "Failed to get .earlierDate()")
 		
 		// laterDate()
 		XCTAssert( (date1.laterDate(date2) == date2), "Failed to get .laterDate()")
 		XCTAssert( (date1.laterDate(date3) == date3), "Failed to get .laterDate()")
-                XCTAssert( (date1.date.laterDate(date2.date) == date2.date), "Failed to get .laterDate()")
-                XCTAssert( (date1.date.laterDate(date3.date) == date3.date), "Failed to get .laterDate()")
+		XCTAssert( (date1.date.laterDate(date2.date) == date2.date), "Failed to get .laterDate()")
+		XCTAssert( (date1.date.laterDate(date3.date) == date3.date), "Failed to get .laterDate()")
 	}
 
 	func testDateInRegion_compareMath() {


### PR DESCRIPTION
Hello.
Thank you for your library.
In this pull request I replaced `timeIntervalSince1970` with `timeIntervalSince` in some functions. As for me it looks more logical. 
Added missing tests for `Date.earlierDate` and `Date.laterDate`.