### PR TITLE
Fix the behavior of dateAt(.startOfMonth)

### DIFF
--- a/Sources/SwiftDate/DateInRegion/DateInRegion+Create.swift
+++ b/Sources/SwiftDate/DateInRegion/DateInRegion+Create.swift
@@ -404,7 +404,7 @@ public extension DateInRegion {
 		case .endOfWeek:
 			return dateAt(.startOfWeek).dateByAdding(7, .day).dateByAdding(-1, .second)
 		case .startOfMonth:
-			return dateBySet([.day: 1, .hour: 1, .minute: 1, .second: 1, .nanosecond: 1])!
+			return dateBySet([.day: 1, .hour: 0, .minute: 0, .second: 0, .nanosecond: 0])!
 		case .endOfMonth:
 			return dateByAdding((monthDays - day), .day).dateAtEndOf(.day)
 		case .tomorrow:

--- a/Tests/SwiftDateTests/TestDateInRegion+Create.swift
+++ b/Tests/SwiftDateTests/TestDateInRegion+Create.swift
@@ -301,4 +301,24 @@ class TestDateInRegion_Create: XCTestCase {
 			"2019-06-07T00:00:00Z"
 		])
 	}
+
+    func testDateInRegion_DateAtStartOf() {
+        let regionRome = Region(calendar: Calendars.gregorian, zone: Zones.europeRome, locale: Locales.italian)
+        let currentDate = DateInRegion(Date(), region: regionRome)
+
+        let startOfDay1 = currentDate.dateAt(.startOfDay).date
+        let startOfDay2 = currentDate.dateAtStartOf(.day).date
+
+        XCTAssert( startOfDay1 == startOfDay2, "dateAt(.startOfDay), dateAtStartOf(.day) are not same.")
+
+        let startOfWeek1 = currentDate.dateAt(.startOfWeek).date
+        let startOfWeek2 = currentDate.dateAtStartOf(.weekOfYear).date
+
+        XCTAssert( startOfWeek1 == startOfWeek2, "dateAt(.startOfWeek), dateAtStartOf(.weekday) are not same.")
+
+        let startOfMonth1 = currentDate.dateAt(.startOfMonth).date
+        let startOfMonth2 = currentDate.dateAtStartOf(.month).date
+
+        XCTAssert( startOfMonth1 == startOfMonth2, "dateAt(.startOfMonth), dateAtStartOf(.month) are not same.")
+    }
 }


### PR DESCRIPTION
Thank you for your great library 😀
Any suggestions and thoughts will be appreciated :) 

I think it's odd that two similar helper functions have different results.
For example
```swift
Date("2019-10-03 15:32:15", format: "yyyy-MM-dd HH:mm:ss").dateAt(.startOfMonth) // 2019-10-01 01:01:01 
Date("2019-10-03 15:32:15", format: "yyyy-MM-dd HH:mm:ss").dateAtStartOf(.month) // 2019-10-01 00:00:00 
```

We can not define the exact moments of endOfDay, endOfWeek, endOfMonth (depending on the minimum time unit you set).
However, it's so clear that startOfDay, startOfWeek, startOfMonth represent certain point in time which is `yyyy-MM-dd 00:00:00`.

So that's why `dateAt(.startOfMonth)`, `dateAtStartOf(.month)`should have same results.
(and it's already same in .startOfDay, .startOfWeek)