### PR TITLE
Fix lint warning in spacing inside DateRelatedType

### DIFF
--- a/Sources/SwiftDate/Formatters/ISOParser.swift
+++ b/Sources/SwiftDate/Formatters/ISOParser.swift
@@ -765,7 +765,7 @@ public class ISOParser: StringToDateTransformable {
 		return char.isDigit
 	}
 
-	/// MARK: - Scanner internal functions
+	// MARK: - Scanner internal functions
 
 	/// Get the value at specified offset from current scanner position without
 	/// moving the current scanner's index.

--- a/Sources/SwiftDate/Supports/Commons.swift
+++ b/Sources/SwiftDate/Supports/Commons.swift
@@ -239,8 +239,8 @@ public enum DateRelatedType {
 	case tomorrowAtStart
 	case yesterday
 	case yesterdayAtStart
-	case nearestMinute(minute:Int)
-	case nearestHour(hour:Int)
+	case nearestMinute(minute: Int)
+	case nearestHour(hour :Int)
 	case nextWeekday(_: WeekDay)
 	case nextDSTDate
 	case prevMonth


### PR DESCRIPTION
We added SwiftDate as an Xcode project to our workspace and we keep seeing changes from git for SwiftDate after the project builds due to SwiftLint auto correcting the files. This is more of a minor annoyance on our side. 🙂