### PR TITLE
Actually use cached flavours in the relative formatter

### DIFF
--- a/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatterLanguage.swift
+++ b/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatterLanguage.swift
@@ -19,8 +19,8 @@ internal class RelativeFormatterLanguagesCache {
     private(set) var cachedValues = [String: [String: Any]]()
 
     func flavoursForLocaleID(_ langID: String) -> [String: Any]? {
-		if let cachedFlavour = cachedValues[langID] {
-			return cachedFlavour
+        if let cachedFlavour = cachedValues[langID] {
+            return cachedFlavour
 		}
         do {
             guard let fullURL = Bundle(for: RelativeFormatter.self).resourceURL?.appendingPathComponent("langs/\(langID).json") else {

--- a/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatterLanguage.swift
+++ b/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatterLanguage.swift
@@ -21,7 +21,7 @@ internal class RelativeFormatterLanguagesCache {
     func flavoursForLocaleID(_ langID: String) -> [String: Any]? {
         if let cachedFlavour = cachedValues[langID] {
             return cachedFlavour
-		}
+        }
         do {
             guard let fullURL = Bundle(for: RelativeFormatter.self).resourceURL?.appendingPathComponent("langs/\(langID).json") else {
                 return nil

--- a/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatterLanguage.swift
+++ b/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatterLanguage.swift
@@ -19,6 +19,9 @@ internal class RelativeFormatterLanguagesCache {
     private(set) var cachedValues = [String: [String: Any]]()
 
     func flavoursForLocaleID(_ langID: String) -> [String: Any]? {
+		if let cachedFlavour = cachedValues[langID] {
+			return cachedFlavour
+		}
         do {
             guard let fullURL = Bundle(for: RelativeFormatter.self).resourceURL?.appendingPathComponent("langs/\(langID).json") else {
                 return nil


### PR DESCRIPTION
The intention of `cachedValues` to me seems to be to cache the deserialised JSON for faster access in subsequent calls.

This only ever seemed to be assigned to, not read from — and this assignment was causing me an EXC_BAD_ACCESS in my app.

This change simply returns the cached value if one is found. This not only prevents the crash in my app, but actually speeds up subsequent relative formatting.