### PR TITLE
Fixed wrong timezone while setup a different SwiftDate.defaultRegion

### DIFF
--- a/Sources/SwiftDate/Supports/Commons.swift
+++ b/Sources/SwiftDate/Supports/Commons.swift
@@ -90,8 +90,8 @@ public struct DateFormats {
 	/// This is the built-in list of all supported formats for auto-parsing of a string to a date.
 	internal static let builtInAutoFormat: [String] =  [
 		DateFormats.iso8601,
-		"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'",
-		"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSS'Z'",
+		"yyyy'-'MM'-'dd'T'HH':'mm':'ssZ",
+		"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSSZ",
 		"yyyy-MM-dd'T'HH:mm:ss.SSSZ",
 		"yyyy-MM-dd HH:mm:ss",
 		"yyyy-MM-dd HH:mm",

--- a/SwiftDate.xcodeproj/xcshareddata/xcschemes/SwiftDate-iOS Tests.xcscheme
+++ b/SwiftDate.xcodeproj/xcshareddata/xcschemes/SwiftDate-iOS Tests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "52D6D9851BEFF229002C0205"
+               BuildableName = "SwiftDate-iOS Tests.xctest"
+               BlueprintName = "SwiftDate-iOS Tests"
+               ReferencedContainer = "container:SwiftDate.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/SwiftDateTests/TestDate.swift
+++ b/Tests/SwiftDateTests/TestDate.swift
@@ -31,5 +31,4 @@ class TestDate: XCTestCase {
         let result = date.difference(in: .day, from: date2)
         print(result!)
     }
-
 }

--- a/Tests/SwiftDateTests/TestSwiftDate.swift
+++ b/Tests/SwiftDateTests/TestSwiftDate.swift
@@ -25,4 +25,19 @@ class TestSwiftDate: XCTestCase {
 		XCTAssert( (SwiftDate.autoFormats == builtInAutoFormats), "Failed to reset auto formats")
 	}
 
+    func testUTCZone() {
+        SwiftDate.defaultRegion = Region(calendar: Calendars.gregorian, zone: Zones.asiaShanghai, locale: Locales.current)
+        
+        // DO NOT recognized the right timezone
+        // The timezone should be UTC
+        let wrongZone = "2020-03-13T05:40:48.000Z"
+        let wrongZoneDate = Date.init(wrongZone)
+        print(wrongZoneDate!.description)
+        XCTAssert("2020-03-13 05:40:48 +0000" == wrongZoneDate!.description)
+        
+        let iso8601Time = "2020-03-13T05:40:48+00:00"
+        let iso8601Date = Date.init(iso8601Time)
+        print(iso8601Date!.description)
+        XCTAssert("2020-03-13 05:40:48 +0000" == iso8601Date!.description)
+    }
 }


### PR DESCRIPTION
Get a wrong timezone while setup a diffent SwiftDate.defaultRegion.

```swift
    func testUTCZone() {
        SwiftDate.defaultRegion = Region(calendar: Calendars.gregorian, zone: Zones.asiaShanghai, locale: Locales.current)
        
        // DO NOT recognized the right timezone
        // The timezone should be UTC
        let wrongZone = "2020-03-13T05:40:48.000Z"
        let wrongZoneDate = Date.init(wrongZone)
        print(wrongZoneDate!.description) 
        // output: 2020-03-12 21:40:48 +0000
        // I think the correct response is : 2020-03-13 05:40:48 +0000
        XCTAssert("2020-03-13 05:40:48 +0000" == wrongZoneDate!.description)
        
        let iso8601Time = "2020-03-13T05:40:48+00:00"
        let iso8601Date = Date.init(iso8601Time)
        print(iso8601Date!.description) // output: 2020-03-13 05:40:48 +0000
        XCTAssert("2020-03-13 05:40:48 +0000" == iso8601Date!.description)
    }
```