### PR TITLE
Fix date comparison using the .isSameMonth option

### DIFF
--- a/Sources/SwiftDate/DateInRegion/DateInRegion+Compare.swift
+++ b/Sources/SwiftDate/DateInRegion/DateInRegion+Compare.swift
@@ -173,7 +173,7 @@ public extension DateInRegion {
 			return compare(.isSameMonth(lastMonth))
 
 		case .isSameMonth(let refDate):
-			return (year == refDate.date.year) && (month == refDate.date.month)
+			return (year == refDate.year) && (month == refDate.month)
 
 		case .isThisYear:
 			return compare(.isSameYear(region.nowInThisRegion()))

--- a/Sources/SwiftDate/DateInRegion/DateInRegion+Compare.swift
+++ b/Sources/SwiftDate/DateInRegion/DateInRegion+Compare.swift
@@ -173,7 +173,7 @@ public extension DateInRegion {
 			return compare(.isSameMonth(lastMonth))
 
 		case .isSameMonth(let refDate):
-			return (date.year == refDate.date.year) && (date.month == refDate.date.month)
+			return (year == refDate.date.year) && (month == refDate.date.month)
 
 		case .isThisYear:
 			return compare(.isSameYear(region.nowInThisRegion()))
@@ -187,7 +187,7 @@ public extension DateInRegion {
 			return compare(.isSameYear(lastYear))
 
 		case .isSameYear(let refDate):
-			return (date.year == refDate.date.year)
+			return (year == refDate.year)
 
 		case .isInTheFuture:
 			return compare(.isLater(than: region.nowInThisRegion()))


### PR DESCRIPTION
Comparing . isSameMonth currently first converts `self` to a Date, with a result that it can become a different month if it's at the end or beginning of the month in a different region. Therefore the existing unit test also fails.

This PR fixes that.