### PR TITLE
Added .asLocale() to String object to transform identifier in an NSLocale object

### DIFF
--- a/Sources/SwiftDate/Foundation+Extras/String+Parser.swift
+++ b/Sources/SwiftDate/Foundation+Extras/String+Parser.swift
@@ -116,5 +116,8 @@ extension String: DateParsable {
 	public func toSQLDate(region: Region = Region.ISO) -> DateInRegion? {
 		return StringToDateStyles.sql.toDate(self, region: region)
 	}
-
+	
+	public func asLocale() -> Locale {
+               Locale(identifier: self)
+        }
 }


### PR DESCRIPTION
Main purpose of this proposition is simplifying access for Locale obj while use of .toFormat() method.

Example of usage
```swift
Date().foFormat("HH:mm", locale: "pl".asLocale())
// instead of
Date().toFormat("HH:mm", locale: Locale(identifier: "pl"))
```