### PR TITLE
Relative date formatter concurrency issue

### DIFF
--- a/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatterLanguage.swift
+++ b/Sources/SwiftDate/Formatters/RelativeFormatter/RelativeFormatterLanguage.swift
@@ -16,8 +16,6 @@ internal class RelativeFormatterLanguagesCache {
 
     static let shared = RelativeFormatterLanguagesCache()
 
-    private(set) var cachedValues = [String: [String: Any]]()
-
     func flavoursForLocaleID(_ langID: String) -> [String: Any]? {
         do {
             guard let fullURL = Bundle(for: RelativeFormatter.self).resourceURL?.appendingPathComponent("langs/\(langID).json") else {
@@ -26,13 +24,7 @@ internal class RelativeFormatterLanguagesCache {
             let data = try Data(contentsOf: fullURL)
             let json = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
 
-            if let value = json as? [String: Any] {
-                cachedValues[langID] = value
-                return value
-            } else {
-                return nil
-            }
-
+            return json as? [String: Any]
         } catch {
             debugPrint("Failed to read data for language id: \(langID)")
             return nil


### PR DESCRIPTION
Hey there,

So we were having some concurrency issues related to to that write on the `cachedValues` dictionary. I was about to make that property atomic/thread safe, but it seems values are being set but never read, so I guess it doesn't make sense to have that dictionary there anymore.

Cheers