### PR TITLE
Update Package.swift to support Xcode 12 and iOS9+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftDate",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .watchOS(.v2), .tvOS(.v9)
+        .macOS(.v10_10), .iOS(.v9), .watchOS(.v2), .tvOS(.v9)
     ],
     products: [
         .library(


### PR DESCRIPTION
Bumped minimum iOS deployment version from 8 to 9 in order to comply with Xcode 12's minimum deployment range. Fixes compiler warning when installing via SPM.