### PR TITLE
add toString support for dateTime with differing date and time styles

### DIFF
--- a/Sources/SwiftDate/Formatters/Formatter+Protocols.swift
+++ b/Sources/SwiftDate/Formatters/Formatter+Protocols.swift
@@ -46,6 +46,7 @@ public enum DateToStringStyles {
 	case date(_: DateFormatter.Style)
 	case time(_: DateFormatter.Style)
 	case dateTime(_: DateFormatter.Style)
+    case dateTimeMixed(dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style)
 	case custom(_: String)
 	case standard
 	case relative(style: RelativeFormatter.Style?)
@@ -76,6 +77,11 @@ public enum DateToStringStyles {
 				$0.dateStyle = style
 				$0.timeStyle = style
 			}).string(from: date.date)
+        case .dateTimeMixed(let dateStyle, let timeStyle):
+            return date.formatterForRegion(format: nil, configuration: {
+                $0.dateStyle = dateStyle
+                $0.timeStyle = timeStyle
+            }).string(from: date.date)
 		case .relative(let style):
 			return RelativeFormatter.format(date, options: style)
 		}


### PR DESCRIPTION
I'm in the middle of finally upgrading from 4.X and could not find any solution for doing mixed styles for date and time. It's currently time-only, date-only, or dateTime which applies the same short/medium/long/full to both...  my codebase from 4.X days has numerous places where we do .long for data and .short for time.

Seem like this should be there, but I don't see it.  Feel free to redirect me to the proper method if I'm missing it.   