### PR TITLE
CocoaPods: Update podspec to iOS9 in order to fix Xcode 12 warning

### DIFF
--- a/SwiftDate.podspec
+++ b/SwiftDate.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author             = { "Daniele Margutti" => "hello@danielemargutti.com" }
   s.social_media_url   = "https://twitter.com/danielemargutti"
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.10"
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"


### PR DESCRIPTION
<img width="463" alt="Screen Shot 2020-11-09 at 6 25 46 AM" src="https://user-images.githubusercontent.com/1163880/98535614-68749480-2254-11eb-94c4-b8566ff12f34.png">

Much like https://github.com/malcommac/SwiftDate/pull/751 this updates the cocoapods podspec to minimum iOS9 deployment target as this was bumped with the Xcode 12 release. 