### PR TITLE
Replace $ sign with % in documentation

### DIFF
--- a/Documentation/0.Informations.md
+++ b/Documentation/0.Informations.md
@@ -27,7 +27,7 @@ All methods and variables have been documented and are available for option+clic
 Unit tests were performed on all the major classes in the library for quality assurance.
 You can find theses under the "Tests" folder at the top of the library.
 
-Currently SwiftDate has ~90$ of code coverage. 
+Currently SwiftDate has ~90% of code coverage. 
 
 If you ever find a test case that is incomplete, please open an issue so we can get it fixed.
 


### PR DESCRIPTION
Replace $ sign with % in code coverage explanation chapter