### PR TITLE
Fixing issue #715 - Slightly different results for dateAt(.endOfDay) and dateAtEndOf(.day)

### DIFF
--- a/Sources/SwiftDate/Date/Date+Create.swift
+++ b/Sources/SwiftDate/Date/Date+Create.swift
@@ -106,7 +106,14 @@ public extension Date {
 	///
 	/// - returns: A new Moment instance.
 	func dateAtEndOf(_ unit: Calendar.Component) -> Date {
-		return inDefaultRegion().dateAtEndOf(unit).date
+        switch unit {
+        case .day:
+            return inDefaultRegion().dateAt(.endOfDay).date
+        case .month:
+            return inDefaultRegion().dateAt(.endOfMonth).date
+        default:
+            return inDefaultRegion().dateAtEndOf(unit).date
+        }
 	}
 
 	/// Return a new DateInRegion that is initialized at the end of the specified components


### PR DESCRIPTION
Fixing issue #715 - Now `dateAtEndOf(_: Calendar.Component)`  will use `dateAt(_: DateRelatedType)` when `.day` or `.month` are provided to avoid equality incostistency.