### PR TITLE
Fixing issue #696 - Is it possible to round to seconds?

### DIFF
--- a/Sources/SwiftDate/DateInRegion/DateInRegion+Create.swift
+++ b/Sources/SwiftDate/DateInRegion/DateInRegion+Create.swift
@@ -324,6 +324,8 @@ public extension DateInRegion {
 	/// - Returns: rounded date
 	func dateRoundedAt(_ style: RoundDateMode) -> DateInRegion {
 		switch style {
+        case .to1Sec:           return dateRoundedAt(.toSecs(1))
+        case .to1Min:           return dateRoundedAt(.toMins(1))
 		case .to5Mins:			return dateRoundedAt(.toMins(5))
 		case .to10Mins:			return dateRoundedAt(.toMins(10))
 		case .to30Mins:			return dateRoundedAt(.toMins(30))
@@ -352,6 +354,24 @@ public extension DateInRegion {
 			let value = -((Int(1.minutes.timeInterval) * remain) + second)
 			return dateByAdding(value, .second)
 
+            
+        case .toSecs(let secondInterval):
+            let onesDigit: Int = (second % 10)
+            if onesDigit < 5 {
+                return dateRoundedAt(.toFloorSecs(secondInterval))
+            } else {
+                return dateRoundedAt(.toCeilSecs(secondInterval))
+            }
+
+        case .toCeilSecs(let secondInterval):
+            let remain: Int = (second % secondInterval)
+            let value = (( Int(1.seconds.timeInterval) * (secondInterval - remain)) - nanosecond)
+            return dateByAdding(value, .nanosecond)
+
+        case .toFloorSecs(let secondInterval):
+            let remain: Int = (second % secondInterval)
+            let value = -((Int(1.seconds.timeInterval) * remain) + nanosecond)
+            return dateByAdding(value, .nanosecond)
 		}
 	}
 

--- a/Sources/SwiftDate/Supports/Commons.swift
+++ b/Sources/SwiftDate/Supports/Commons.swift
@@ -236,18 +236,23 @@ public extension Calendar.Component {
 /// Rounding mode for dates.
 /// Round off/up (ceil) or down (floor) target date.
 public enum RoundDateMode {
+    case to1Sec
+    case to1Min
 	case to5Mins
 	case to10Mins
 	case to30Mins
 	case toMins(_: Int)
+    case toSecs(_: Int)
 	case toCeil5Mins
 	case toCeil10Mins
 	case toCeil30Mins
 	case toCeilMins(_: Int)
+    case toCeilSecs(_: Int)
 	case toFloor5Mins
 	case toFloor10Mins
 	case toFloor30Mins
 	case toFloorMins(_: Int)
+    case toFloorSecs(_: Int)
 }
 
 /// Related type enum to get derivated date from a receiver date.


### PR DESCRIPTION
Fixing issue #696 - `.toFloorSecs(_)`, `.toCeilSecs(_)`, `.toSecs(_)`, `.to1Sec(_)` and `.to1min(_)` are added to the `RoundDateMode`s, to be used by `dateRoundedAt(_: RoundDateMode)`