### PR TITLE
Remove resources param on SPM target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,11 +15,8 @@ let package = Package(
     targets: [
         .target(
             name: "SwiftDate",
-            dependencies: [],
-			resources: [
-				.copy("Formatters/RelativeFormatter/langs"),
-                .process("Resources")
-			]),
+            dependencies: []
+			),
         .testTarget(
             name: "SwiftDateTests",
             dependencies: ["SwiftDate"])


### PR DESCRIPTION
There is a `resources` param on the SwiftDate target definition. However, those resources were removed since version 7.0.0.
Because of this param, SPM resolution of this library is not working with Tuist SPM Dependencies - Tuist denies this library due to missing resources.

Removing `resources` param makes Tuist work with this library.

