### PR TITLE
Update Commons.swift: Added a comment to toCeilMins that mins needs to be >= 1

### DIFF
--- a/Sources/SwiftDate/Supports/Commons.swift
+++ b/Sources/SwiftDate/Supports/Commons.swift
@@ -243,6 +243,7 @@ public enum RoundDateMode {
 	case toCeil5Mins
 	case toCeil10Mins
 	case toCeil30Mins
+	/// mins must be >= 1
 	case toCeilMins(_: Int)
 	case toFloor5Mins
 	case toFloor10Mins


### PR DESCRIPTION
Added a comment that might save others some time trying to fix a divide by zero crash if mistakenly doing `.toCeilMins(0)` like I did.