### PR TITLE
Remove duplicate conditions in switch statement to fix build errors.

### DIFF
--- a/Sources/SwiftDate/Supports/Calendars.swift
+++ b/Sources/SwiftDate/Supports/Calendars.swift
@@ -84,7 +84,6 @@ extension Calendar.Identifier: CustomStringConvertible {
 		case Calendar.Identifier.persian.description:				self = .persian
 		case Calendar.Identifier.republicOfChina.description:		self = .republicOfChina
 		case Calendar.Identifier.islamicTabular.description:		self = .islamicTabular
-		case Calendar.Identifier.islamicTabular.description:		self = .islamicTabular
 		case Calendar.Identifier.islamicUmmAlQura.description:		self = .islamicUmmAlQura
 		default:
 			let defaultCalendar = SwiftDate.defaultRegion.calendar.identifier


### PR DESCRIPTION
Hello,

I've made a small change to fix build errors caused by duplicate conditions in a switch statement. 
The errors were as follows:
```
SwiftDate/Sources/SwiftDate/Supports/Calendars.swift:86:8: error: Duplicate Conditions Violation: Duplicate sets of conditions in the same branch instruction should be avoided (duplicate_conditions)
SwiftDate/Sources/SwiftDate/Supports/Calendars.swift:87:8: error: Duplicate Conditions Violation: Duplicate sets of conditions in the same branch instruction should be avoided (duplicate_conditions)
```

To resolve these errors, I removed the duplicate case statements in the switch block.

Build environment
Xcode: 14.3
macOS: 13.3