### PR TITLE
Fix build, and fix xcodeproj missing files

### DIFF
--- a/Sources/SwiftDate/Supports/Calendars.swift
+++ b/Sources/SwiftDate/Supports/Calendars.swift
@@ -84,7 +84,6 @@ extension Calendar.Identifier: CustomStringConvertible {
 		case Calendar.Identifier.persian.description:				self = .persian
 		case Calendar.Identifier.republicOfChina.description:		self = .republicOfChina
 		case Calendar.Identifier.islamicTabular.description:		self = .islamicTabular
-		case Calendar.Identifier.islamicTabular.description:		self = .islamicTabular
 		case Calendar.Identifier.islamicUmmAlQura.description:		self = .islamicUmmAlQura
 		default:
 			let defaultCalendar = SwiftDate.defaultRegion.calendar.identifier

--- a/SwiftDate.xcodeproj/project.pbxproj
+++ b/SwiftDate.xcodeproj/project.pbxproj
@@ -80,16 +80,6 @@
 		647AD65C21F4851F00CF787E /* TestDataStructures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647AD65B21F4851F00CF787E /* TestDataStructures.swift */; };
 		647AD65D21F4851F00CF787E /* TestDataStructures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647AD65B21F4851F00CF787E /* TestDataStructures.swift */; };
 		647AD65E21F4851F00CF787E /* TestDataStructures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647AD65B21F4851F00CF787E /* TestDataStructures.swift */; };
-		64990AF82286FC31006C427D /* langs in Resources */ = {isa = PBXBuildFile; fileRef = 64990AF72286FC31006C427D /* langs */; };
-		64990AF92286FC31006C427D /* langs in Resources */ = {isa = PBXBuildFile; fileRef = 64990AF72286FC31006C427D /* langs */; };
-		64990AFA2286FC31006C427D /* langs in Resources */ = {isa = PBXBuildFile; fileRef = 64990AF72286FC31006C427D /* langs */; };
-		64990AFB2286FC31006C427D /* langs in Resources */ = {isa = PBXBuildFile; fileRef = 64990AF72286FC31006C427D /* langs */; };
-		64990AFC2286FC31006C427D /* langs in Resources */ = {isa = PBXBuildFile; fileRef = 64990AF72286FC31006C427D /* langs */; };
-		649D0E032287412C0056D42E /* RelativeFormatterLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D0E022287412C0056D42E /* RelativeFormatterLanguage.swift */; };
-		649D0E042287412C0056D42E /* RelativeFormatterLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D0E022287412C0056D42E /* RelativeFormatterLanguage.swift */; };
-		649D0E052287412C0056D42E /* RelativeFormatterLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D0E022287412C0056D42E /* RelativeFormatterLanguage.swift */; };
-		649D0E062287412C0056D42E /* RelativeFormatterLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D0E022287412C0056D42E /* RelativeFormatterLanguage.swift */; };
-		649D0E072287412C0056D42E /* RelativeFormatterLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D0E022287412C0056D42E /* RelativeFormatterLanguage.swift */; };
 		649D473B20C81A2A00513A67 /* DateRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D473A20C81A2A00513A67 /* DateRepresentable.swift */; };
 		649D473C20C81A2A00513A67 /* DateRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D473A20C81A2A00513A67 /* DateRepresentable.swift */; };
 		649D473D20C81A2A00513A67 /* DateRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D473A20C81A2A00513A67 /* DateRepresentable.swift */; };
@@ -180,16 +170,6 @@
 		649D47C420C964E000513A67 /* Int+DateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47C120C964E000513A67 /* Int+DateComponents.swift */; };
 		649D47C520C964E000513A67 /* Int+DateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47C120C964E000513A67 /* Int+DateComponents.swift */; };
 		649D47C620C964E000513A67 /* Int+DateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47C120C964E000513A67 /* Int+DateComponents.swift */; };
-		649D47E120CAAB7400513A67 /* RelativeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47E020CAAB7400513A67 /* RelativeFormatter.swift */; };
-		649D47E220CAAB7400513A67 /* RelativeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47E020CAAB7400513A67 /* RelativeFormatter.swift */; };
-		649D47E320CAAB7400513A67 /* RelativeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47E020CAAB7400513A67 /* RelativeFormatter.swift */; };
-		649D47E420CAAB7400513A67 /* RelativeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47E020CAAB7400513A67 /* RelativeFormatter.swift */; };
-		649D47E520CAAB7400513A67 /* RelativeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47E020CAAB7400513A67 /* RelativeFormatter.swift */; };
-		649D47EE20CAB96D00513A67 /* RelativeFormatter+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47ED20CAB96D00513A67 /* RelativeFormatter+Style.swift */; };
-		649D47EF20CAB96D00513A67 /* RelativeFormatter+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47ED20CAB96D00513A67 /* RelativeFormatter+Style.swift */; };
-		649D47F020CAB96D00513A67 /* RelativeFormatter+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47ED20CAB96D00513A67 /* RelativeFormatter+Style.swift */; };
-		649D47F120CAB96D00513A67 /* RelativeFormatter+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47ED20CAB96D00513A67 /* RelativeFormatter+Style.swift */; };
-		649D47F220CAB96D00513A67 /* RelativeFormatter+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D47ED20CAB96D00513A67 /* RelativeFormatter+Style.swift */; };
 		64B5E25320D306220067EDC1 /* TimePeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B5E25220D306220067EDC1 /* TimePeriod.swift */; };
 		64B5E25420D306220067EDC1 /* TimePeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B5E25220D306220067EDC1 /* TimePeriod.swift */; };
 		64B5E25520D306220067EDC1 /* TimePeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B5E25220D306220067EDC1 /* TimePeriod.swift */; };
@@ -210,9 +190,6 @@
 		64B5E26820D30E620067EDC1 /* TimePeriodChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B5E26520D30E620067EDC1 /* TimePeriodChain.swift */; };
 		64B5E26920D30E620067EDC1 /* TimePeriodChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B5E26520D30E620067EDC1 /* TimePeriodChain.swift */; };
 		64B5E26A20D30E620067EDC1 /* TimePeriodChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B5E26520D30E620067EDC1 /* TimePeriodChain.swift */; };
-		64BAB12420E63A3A00FEED79 /* TestDateInRegion+Langs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BAB12320E63A3A00FEED79 /* TestDateInRegion+Langs.swift */; };
-		64BAB12520E63A3A00FEED79 /* TestDateInRegion+Langs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BAB12320E63A3A00FEED79 /* TestDateInRegion+Langs.swift */; };
-		64BAB12620E63A3A00FEED79 /* TestDateInRegion+Langs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BAB12320E63A3A00FEED79 /* TestDateInRegion+Langs.swift */; };
 		64BAB12820E6411100FEED79 /* TestSwiftDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BAB12720E6411100FEED79 /* TestSwiftDate.swift */; };
 		64BAB12920E6411100FEED79 /* TestSwiftDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BAB12720E6411100FEED79 /* TestSwiftDate.swift */; };
 		64BAB12A20E6411100FEED79 /* TestSwiftDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BAB12720E6411100FEED79 /* TestSwiftDate.swift */; };
@@ -288,8 +265,6 @@
 		647AD65521F4826100CF787E /* TimeStructures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeStructures.swift; sourceTree = "<group>"; };
 		647AD65B21F4851F00CF787E /* TestDataStructures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDataStructures.swift; sourceTree = "<group>"; };
 		647DA61A20D3FAB800E20E8C /* Documentation */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Documentation; sourceTree = "<group>"; };
-		64990AF72286FC31006C427D /* langs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = langs; sourceTree = "<group>"; };
-		649D0E022287412C0056D42E /* RelativeFormatterLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeFormatterLanguage.swift; sourceTree = "<group>"; };
 		649D473A20C81A2A00513A67 /* DateRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DateRepresentable.swift; path = SwiftDate/DateRepresentable.swift; sourceTree = "<group>"; };
 		649D474020C81A4200513A67 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		649D474720C8241C00513A67 /* Commons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Commons.swift; sourceTree = "<group>"; };
@@ -308,13 +283,10 @@
 		649D47B520C9586500513A67 /* DateInRegion+Math.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateInRegion+Math.swift"; sourceTree = "<group>"; };
 		649D47BB20C959F500513A67 /* Date+Math.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Math.swift"; sourceTree = "<group>"; };
 		649D47C120C964E000513A67 /* Int+DateComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+DateComponents.swift"; sourceTree = "<group>"; };
-		649D47E020CAAB7400513A67 /* RelativeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeFormatter.swift; sourceTree = "<group>"; };
-		649D47ED20CAB96D00513A67 /* RelativeFormatter+Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RelativeFormatter+Style.swift"; sourceTree = "<group>"; };
 		64B5E25220D306220067EDC1 /* TimePeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePeriod.swift; sourceTree = "<group>"; };
 		64B5E25820D3090A0067EDC1 /* TimePeriodGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePeriodGroup.swift; sourceTree = "<group>"; };
 		64B5E25F20D30AE40067EDC1 /* TimePeriodCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePeriodCollection.swift; sourceTree = "<group>"; };
 		64B5E26520D30E620067EDC1 /* TimePeriodChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePeriodChain.swift; sourceTree = "<group>"; };
-		64BAB12320E63A3A00FEED79 /* TestDateInRegion+Langs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TestDateInRegion+Langs.swift"; sourceTree = "<group>"; };
 		64BAB12720E6411100FEED79 /* TestSwiftDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSwiftDate.swift; sourceTree = "<group>"; };
 		64EF3E0220D5518D002793C6 /* TestRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRegion.swift; sourceTree = "<group>"; };
 		64EF3E0620D56038002793C6 /* TestDateInRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDateInRegion.swift; sourceTree = "<group>"; };
@@ -513,21 +485,9 @@
 				649D475920C84FAC00513A67 /* ISOFormatter.swift */,
 				649D476C20C85C7100513A67 /* ISOParser.swift */,
 				649D477220C872DA00513A67 /* DotNetParserFormatter.swift */,
-				649D47E620CAB46400513A67 /* RelativeFormatter */,
 			);
 			name = Formatters;
 			path = SwiftDate/Formatters;
-			sourceTree = "<group>";
-		};
-		649D47E620CAB46400513A67 /* RelativeFormatter */ = {
-			isa = PBXGroup;
-			children = (
-				649D47E020CAAB7400513A67 /* RelativeFormatter.swift */,
-				649D47ED20CAB96D00513A67 /* RelativeFormatter+Style.swift */,
-				649D0E022287412C0056D42E /* RelativeFormatterLanguage.swift */,
-				64990AF72286FC31006C427D /* langs */,
-			);
-			path = RelativeFormatter;
 			sourceTree = "<group>";
 		};
 		64B5E25E20D309210067EDC1 /* Groups */ = {
@@ -564,7 +524,6 @@
 				64EF3E0E20D65478002793C6 /* TestDateInRegion+Compare.swift */,
 				6439231D20D90CB10098EC03 /* TestDateInRegion+Components.swift */,
 				6439232120D912670098EC03 /* TestDateInRegion+Math.swift */,
-				64BAB12320E63A3A00FEED79 /* TestDateInRegion+Langs.swift */,
 				6439232520D91D170098EC03 /* TestFormatters.swift */,
 				64BAB12720E6411100FEED79 /* TestSwiftDate.swift */,
 				647AD65B21F4851F00CF787E /* TestDataStructures.swift */,
@@ -844,7 +803,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				64990AF82286FC31006C427D /* langs in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -859,7 +817,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				64990AFA2286FC31006C427D /* langs in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -867,7 +824,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				64990AFB2286FC31006C427D /* langs in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -875,7 +831,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				64990AF92286FC31006C427D /* langs in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -885,7 +840,6 @@
 			files = (
 				6434DD9920C809B4007626EF /* LaunchScreen.storyboard in Resources */,
 				6434DD9620C809B4007626EF /* Assets.xcassets in Resources */,
-				64990AFC2286FC31006C427D /* langs in Resources */,
 				6434DD9420C809B3007626EF /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -931,13 +885,11 @@
 				64B5E26020D30AE40067EDC1 /* TimePeriodCollection.swift in Sources */,
 				649D473B20C81A2A00513A67 /* DateRepresentable.swift in Sources */,
 				6470DD1420D27AF500BC2E74 /* String+Parser.swift in Sources */,
-				649D47E120CAAB7400513A67 /* RelativeFormatter.swift in Sources */,
 				6470DD2E20D2B64200BC2E74 /* TimePeriod+Support.swift in Sources */,
 				64B5E26620D30E620067EDC1 /* TimePeriodChain.swift in Sources */,
 				649D474120C81A4200513A67 /* Date.swift in Sources */,
 				649D476D20C85C7100513A67 /* ISOParser.swift in Sources */,
 				6434DD7C20C803EF007626EF /* SwiftDate.swift in Sources */,
-				649D0E032287412C0056D42E /* RelativeFormatterLanguage.swift in Sources */,
 				649D47BC20C959F500513A67 /* Date+Math.swift in Sources */,
 				649D47AA20C91C0B00513A67 /* Date+Compare.swift in Sources */,
 				6434DD7220C80126007626EF /* Calendars.swift in Sources */,
@@ -956,7 +908,6 @@
 				6434DD6120C7FAF6007626EF /* DateInRegion.swift in Sources */,
 				649D47B620C9586500513A67 /* DateInRegion+Math.swift in Sources */,
 				649D479220C913E200513A67 /* Date+Components.swift in Sources */,
-				649D47EE20CAB96D00513A67 /* RelativeFormatter+Style.swift in Sources */,
 				6470DD1A20D296EA00BC2E74 /* TimeInterval+Formatter.swift in Sources */,
 				6434DD6720C7FC6A007626EF /* Region.swift in Sources */,
 				649D47A420C91BEA00513A67 /* DateInRegion+Compare.swift in Sources */,
@@ -971,7 +922,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				64BAB12420E63A3A00FEED79 /* TestDateInRegion+Langs.swift in Sources */,
 				647AD65C21F4851F00CF787E /* TestDataStructures.swift in Sources */,
 				6439232220D912670098EC03 /* TestDateInRegion+Math.swift in Sources */,
 				64EF3E0F20D65478002793C6 /* TestDateInRegion+Compare.swift in Sources */,
@@ -991,13 +941,11 @@
 				64B5E26220D30AE40067EDC1 /* TimePeriodCollection.swift in Sources */,
 				649D473D20C81A2A00513A67 /* DateRepresentable.swift in Sources */,
 				6470DD1620D27AF500BC2E74 /* String+Parser.swift in Sources */,
-				649D47E320CAAB7400513A67 /* RelativeFormatter.swift in Sources */,
 				6470DD3020D2B64200BC2E74 /* TimePeriod+Support.swift in Sources */,
 				64B5E26820D30E620067EDC1 /* TimePeriodChain.swift in Sources */,
 				649D474320C81A4200513A67 /* Date.swift in Sources */,
 				649D476F20C85C7100513A67 /* ISOParser.swift in Sources */,
 				6434DD7E20C803EF007626EF /* SwiftDate.swift in Sources */,
-				649D0E052287412C0056D42E /* RelativeFormatterLanguage.swift in Sources */,
 				649D47BE20C959F500513A67 /* Date+Math.swift in Sources */,
 				649D47AC20C91C0B00513A67 /* Date+Compare.swift in Sources */,
 				6434DD7420C80126007626EF /* Calendars.swift in Sources */,
@@ -1016,7 +964,6 @@
 				6434DD6320C7FAF6007626EF /* DateInRegion.swift in Sources */,
 				649D47B820C9586500513A67 /* DateInRegion+Math.swift in Sources */,
 				649D479420C913E200513A67 /* Date+Components.swift in Sources */,
-				649D47F020CAB96D00513A67 /* RelativeFormatter+Style.swift in Sources */,
 				6470DD1C20D296EA00BC2E74 /* TimeInterval+Formatter.swift in Sources */,
 				6434DD6920C7FC6A007626EF /* Region.swift in Sources */,
 				649D47A620C91BEA00513A67 /* DateInRegion+Compare.swift in Sources */,
@@ -1034,13 +981,11 @@
 				64B5E26320D30AE40067EDC1 /* TimePeriodCollection.swift in Sources */,
 				649D473E20C81A2A00513A67 /* DateRepresentable.swift in Sources */,
 				6470DD1720D27AF500BC2E74 /* String+Parser.swift in Sources */,
-				649D47E420CAAB7400513A67 /* RelativeFormatter.swift in Sources */,
 				6470DD3120D2B64200BC2E74 /* TimePeriod+Support.swift in Sources */,
 				64B5E26920D30E620067EDC1 /* TimePeriodChain.swift in Sources */,
 				649D474420C81A4200513A67 /* Date.swift in Sources */,
 				649D477020C85C7100513A67 /* ISOParser.swift in Sources */,
 				6434DD7F20C803EF007626EF /* SwiftDate.swift in Sources */,
-				649D0E062287412C0056D42E /* RelativeFormatterLanguage.swift in Sources */,
 				649D47BF20C959F500513A67 /* Date+Math.swift in Sources */,
 				649D47AD20C91C0B00513A67 /* Date+Compare.swift in Sources */,
 				6434DD7520C80126007626EF /* Calendars.swift in Sources */,
@@ -1059,7 +1004,6 @@
 				6434DD6420C7FAF6007626EF /* DateInRegion.swift in Sources */,
 				649D47B920C9586500513A67 /* DateInRegion+Math.swift in Sources */,
 				649D479520C913E200513A67 /* Date+Components.swift in Sources */,
-				649D47F120CAB96D00513A67 /* RelativeFormatter+Style.swift in Sources */,
 				6470DD1D20D296EA00BC2E74 /* TimeInterval+Formatter.swift in Sources */,
 				6434DD6A20C7FC6A007626EF /* Region.swift in Sources */,
 				649D47A720C91BEA00513A67 /* DateInRegion+Compare.swift in Sources */,
@@ -1077,13 +1021,11 @@
 				64B5E26120D30AE40067EDC1 /* TimePeriodCollection.swift in Sources */,
 				649D473C20C81A2A00513A67 /* DateRepresentable.swift in Sources */,
 				6470DD1520D27AF500BC2E74 /* String+Parser.swift in Sources */,
-				649D47E220CAAB7400513A67 /* RelativeFormatter.swift in Sources */,
 				6470DD2F20D2B64200BC2E74 /* TimePeriod+Support.swift in Sources */,
 				64B5E26720D30E620067EDC1 /* TimePeriodChain.swift in Sources */,
 				649D474220C81A4200513A67 /* Date.swift in Sources */,
 				649D476E20C85C7100513A67 /* ISOParser.swift in Sources */,
 				6434DD7D20C803EF007626EF /* SwiftDate.swift in Sources */,
-				649D0E042287412C0056D42E /* RelativeFormatterLanguage.swift in Sources */,
 				649D47BD20C959F500513A67 /* Date+Math.swift in Sources */,
 				649D47AB20C91C0B00513A67 /* Date+Compare.swift in Sources */,
 				6434DD7320C80126007626EF /* Calendars.swift in Sources */,
@@ -1102,7 +1044,6 @@
 				6434DD6220C7FAF6007626EF /* DateInRegion.swift in Sources */,
 				649D47B720C9586500513A67 /* DateInRegion+Math.swift in Sources */,
 				649D479320C913E200513A67 /* Date+Components.swift in Sources */,
-				649D47EF20CAB96D00513A67 /* RelativeFormatter+Style.swift in Sources */,
 				6470DD1B20D296EA00BC2E74 /* TimeInterval+Formatter.swift in Sources */,
 				6434DD6820C7FC6A007626EF /* Region.swift in Sources */,
 				649D47A520C91BEA00513A67 /* DateInRegion+Compare.swift in Sources */,
@@ -1117,11 +1058,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				649D0E072287412C0056D42E /* RelativeFormatterLanguage.swift in Sources */,
 				649D475E20C84FAC00513A67 /* ISOFormatter.swift in Sources */,
 				64B5E26A20D30E620067EDC1 /* TimePeriodChain.swift in Sources */,
 				6434DDA020C809C2007626EF /* Calendars.swift in Sources */,
-				649D47E520CAAB7400513A67 /* RelativeFormatter.swift in Sources */,
 				6470DD1820D27AF500BC2E74 /* String+Parser.swift in Sources */,
 				649D475220C827C400513A67 /* AssociatedValues.swift in Sources */,
 				6434DDA120C809C2007626EF /* Locales.swift in Sources */,
@@ -1152,7 +1091,6 @@
 				6470DD1E20D296EA00BC2E74 /* TimeInterval+Formatter.swift in Sources */,
 				6434DD8F20C809B3007626EF /* AppDelegate.swift in Sources */,
 				649D478920C8861200513A67 /* DateInRegion+Components.swift in Sources */,
-				649D47F220CAB96D00513A67 /* RelativeFormatter+Style.swift in Sources */,
 				6434DD9E20C809C2007626EF /* SwiftDate.swift in Sources */,
 				64B5E25D20D3090A0067EDC1 /* TimePeriodGroup.swift in Sources */,
 			);
@@ -1162,7 +1100,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				64BAB12520E63A3A00FEED79 /* TestDateInRegion+Langs.swift in Sources */,
 				647AD65D21F4851F00CF787E /* TestDataStructures.swift in Sources */,
 				A89F3FAF22A00019002D1BD0 /* TestDate.swift in Sources */,
 				6439232320D912670098EC03 /* TestDateInRegion+Math.swift in Sources */,
@@ -1180,7 +1117,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				64BAB12620E63A3A00FEED79 /* TestDateInRegion+Langs.swift in Sources */,
 				647AD65E21F4851F00CF787E /* TestDataStructures.swift in Sources */,
 				6439232420D912670098EC03 /* TestDateInRegion+Math.swift in Sources */,
 				64EF3E1120D65478002793C6 /* TestDateInRegion+Compare.swift in Sources */,
@@ -1359,7 +1295,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Configs/SwiftDate.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 6.3.1;
 				ONLY_ACTIVE_ARCH = NO;
@@ -1383,7 +1319,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Configs/SwiftDate.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 6.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.SwiftDate.SwiftDate-iOS";
@@ -1399,6 +1335,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = Configs/SwiftDateTests.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.SwiftDate.SwiftDate-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1412,6 +1349,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = Configs/SwiftDateTests.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.SwiftDate.SwiftDate-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
When using the latest swiftlint [0.51.0](https://github.com/realm/SwiftLint/releases/tag/0.51.0), xcodeproj's prebuild script occurs a fatal error.
So, the build failed for users who use carthage and install the latest swiftlint.

And, xcodeproj file contains missing reference files. So I deleted it.

This PR contains the following:
- [x] Fix swiftlint serious violations.
- [x] Delete missing reference in xcodeproj
- [x] Equal xcodeproj's ios minimum development target to Package.swift

Environment:
- carthage 0.39.0
- swiftlint 0.51.0
- Xcode 14.2.0
- Mac OS Ventura 13.2.1（22D68）
